### PR TITLE
fix: add CursorBlink setting

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -63,6 +63,7 @@ module.exports = grammar({
       seq('MarginFill',    $.string),
       seq('WindowBar',     $.string),
       seq('WindowBarSize', $.integer),
+      seq('CursorBlink', $.boolean),
     ),
 
     string: $ =>  choice(/"[^"]*"/, /'[^']*'/, /`[^`]*`/),
@@ -73,5 +74,6 @@ module.exports = grammar({
     path: $ =>    /[\.\-\/A-Za-z0-9%]+/,
     speed: $ =>   seq('@', $.time),
     time: $ =>    /\d*\.?\d+m?s?/,
+    boolean: $ => /true|false/,
   }
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,7 +1,7 @@
 {
   "name": "tree-sitter-cassette",
   "version": "0.1.0",
-  "lockfileVersion": 2,
+  "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
@@ -16,32 +16,19 @@
       }
     },
     "node_modules/nan": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.16.0.tgz",
-      "integrity": "sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA=="
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
+      "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ=="
     },
     "node_modules/tree-sitter-cli": {
-      "version": "0.20.7",
-      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.20.7.tgz",
-      "integrity": "sha512-MHABT8oCPr4D0fatsPo6ATQ9H4h9vHpPRjlxkxJs80tpfAEKGn6A1zU3eqfCKBcgmfZDe9CiL3rKOGMzYHwA3w==",
+      "version": "0.20.8",
+      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.20.8.tgz",
+      "integrity": "sha512-XjTcS3wdTy/2cc/ptMLc/WRyOLECRYcMTrSWyhZnj1oGSOWbHLTklgsgRICU3cPfb0vy+oZCC33M43u6R1HSCA==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
         "tree-sitter": "cli.js"
       }
-    }
-  },
-  "dependencies": {
-    "nan": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.16.0.tgz",
-      "integrity": "sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA=="
-    },
-    "tree-sitter-cli": {
-      "version": "0.20.7",
-      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.20.7.tgz",
-      "integrity": "sha512-MHABT8oCPr4D0fatsPo6ATQ9H4h9vHpPRjlxkxJs80tpfAEKGn6A1zU3eqfCKBcgmfZDe9CiL3rKOGMzYHwA3w==",
-      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "Tree-sitter parser for the Cassette language",
   "main": "bindings/node",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
     "generate": "./node_modules/tree-sitter-cli/tree-sitter generate",
     "test": "./node_modules/tree-sitter-cli/tree-sitter test",
     "parse": "./node_modules/tree-sitter-cli/tree-sitter parse test.tape",

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -27,7 +27,13 @@
   "Padding"
   "Theme"
   "LoopOffset"
-  "Width" ] @type
+  "Width"
+  "BorderRadius"
+  "Margin"
+  "MarginFill"
+  "WindowBar"
+  "WindowBarSize"
+  "CursorBlink" ] @type
 
 [ "@" ] @operator
 (control) @function.macro
@@ -36,3 +42,4 @@
 (comment) @comment @spell
 [(path) (string) (json)] @string
 (time) @symbol
+(boolean) @boolean

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -816,6 +816,19 @@
               "name": "integer"
             }
           ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "CursorBlink"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "boolean"
+            }
+          ]
         }
       ]
     },
@@ -872,6 +885,10 @@
     "time": {
       "type": "PATTERN",
       "value": "\\d*\\.?\\d+m?s?"
+    },
+    "boolean": {
+      "type": "PATTERN",
+      "value": "true|false"
     }
   },
   "extras": [

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -301,6 +301,10 @@
       "required": true,
       "types": [
         {
+          "type": "boolean",
+          "named": true
+        },
+        {
           "type": "float",
           "named": true
         },
@@ -456,6 +460,10 @@
     "named": false
   },
   {
+    "type": "CursorBlink",
+    "named": false
+  },
+  {
     "type": "Down",
     "named": false
   },
@@ -589,6 +597,10 @@
   },
   {
     "type": "alt",
+    "named": true
+  },
+  {
+    "type": "boolean",
     "named": true
   },
   {

--- a/src/parser.c
+++ b/src/parser.c
@@ -6,11 +6,11 @@
 #endif
 
 #define LANGUAGE_VERSION 14
-#define STATE_COUNT 75
+#define STATE_COUNT 76
 #define LARGE_STATE_COUNT 4
-#define SYMBOL_COUNT 73
+#define SYMBOL_COUNT 75
 #define ALIAS_COUNT 0
-#define TOKEN_COUNT 49
+#define TOKEN_COUNT 51
 #define EXTERNAL_TOKEN_COUNT 0
 #define FIELD_COUNT 0
 #define MAX_ALIAS_SEQUENCE_LENGTH 3
@@ -55,40 +55,42 @@ enum {
   anon_sym_MarginFill = 36,
   anon_sym_WindowBar = 37,
   anon_sym_WindowBarSize = 38,
-  aux_sym_string_token1 = 39,
-  aux_sym_string_token2 = 40,
-  aux_sym_string_token3 = 41,
-  sym_comment = 42,
-  sym_float = 43,
-  sym_integer = 44,
-  sym_json = 45,
-  sym_path = 46,
-  anon_sym_AT = 47,
-  sym_time = 48,
-  sym_program = 49,
-  sym_command = 50,
-  sym_hide = 51,
-  sym_show = 52,
-  sym_output = 53,
-  sym_set = 54,
-  sym_sleep = 55,
-  sym_type = 56,
-  sym_backspace = 57,
-  sym_down = 58,
-  sym_enter = 59,
-  sym_escape = 60,
-  sym_left = 61,
-  sym_right = 62,
-  sym_space = 63,
-  sym_tab = 64,
-  sym_up = 65,
-  sym_pageup = 66,
-  sym_pagedown = 67,
-  sym_setting = 68,
-  sym_string = 69,
-  sym_speed = 70,
-  aux_sym_program_repeat1 = 71,
-  aux_sym_type_repeat1 = 72,
+  anon_sym_CursorBlink = 39,
+  aux_sym_string_token1 = 40,
+  aux_sym_string_token2 = 41,
+  aux_sym_string_token3 = 42,
+  sym_comment = 43,
+  sym_float = 44,
+  sym_integer = 45,
+  sym_json = 46,
+  sym_path = 47,
+  anon_sym_AT = 48,
+  sym_time = 49,
+  sym_boolean = 50,
+  sym_program = 51,
+  sym_command = 52,
+  sym_hide = 53,
+  sym_show = 54,
+  sym_output = 55,
+  sym_set = 56,
+  sym_sleep = 57,
+  sym_type = 58,
+  sym_backspace = 59,
+  sym_down = 60,
+  sym_enter = 61,
+  sym_escape = 62,
+  sym_left = 63,
+  sym_right = 64,
+  sym_space = 65,
+  sym_tab = 66,
+  sym_up = 67,
+  sym_pageup = 68,
+  sym_pagedown = 69,
+  sym_setting = 70,
+  sym_string = 71,
+  sym_speed = 72,
+  aux_sym_program_repeat1 = 73,
+  aux_sym_type_repeat1 = 74,
 };
 
 static const char * const ts_symbol_names[] = {
@@ -131,6 +133,7 @@ static const char * const ts_symbol_names[] = {
   [anon_sym_MarginFill] = "MarginFill",
   [anon_sym_WindowBar] = "WindowBar",
   [anon_sym_WindowBarSize] = "WindowBarSize",
+  [anon_sym_CursorBlink] = "CursorBlink",
   [aux_sym_string_token1] = "string_token1",
   [aux_sym_string_token2] = "string_token2",
   [aux_sym_string_token3] = "string_token3",
@@ -141,6 +144,7 @@ static const char * const ts_symbol_names[] = {
   [sym_path] = "path",
   [anon_sym_AT] = "@",
   [sym_time] = "time",
+  [sym_boolean] = "boolean",
   [sym_program] = "program",
   [sym_command] = "command",
   [sym_hide] = "hide",
@@ -207,6 +211,7 @@ static const TSSymbol ts_symbol_map[] = {
   [anon_sym_MarginFill] = anon_sym_MarginFill,
   [anon_sym_WindowBar] = anon_sym_WindowBar,
   [anon_sym_WindowBarSize] = anon_sym_WindowBarSize,
+  [anon_sym_CursorBlink] = anon_sym_CursorBlink,
   [aux_sym_string_token1] = aux_sym_string_token1,
   [aux_sym_string_token2] = aux_sym_string_token2,
   [aux_sym_string_token3] = aux_sym_string_token3,
@@ -217,6 +222,7 @@ static const TSSymbol ts_symbol_map[] = {
   [sym_path] = sym_path,
   [anon_sym_AT] = anon_sym_AT,
   [sym_time] = sym_time,
+  [sym_boolean] = sym_boolean,
   [sym_program] = sym_program,
   [sym_command] = sym_command,
   [sym_hide] = sym_hide,
@@ -400,6 +406,10 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = false,
   },
+  [anon_sym_CursorBlink] = {
+    .visible = true,
+    .named = false,
+  },
   [aux_sym_string_token1] = {
     .visible = false,
     .named = false,
@@ -437,6 +447,10 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .named = false,
   },
   [sym_time] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_boolean] = {
     .visible = true,
     .named = true,
   },
@@ -622,6 +636,7 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [72] = 72,
   [73] = 73,
   [74] = 74,
+  [75] = 75,
 };
 
 static bool ts_lex(TSLexer *lexer, TSStateId state) {
@@ -629,884 +644,941 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
   eof = lexer->eof(lexer);
   switch (state) {
     case 0:
-      if (eof) ADVANCE(196);
+      if (eof) ADVANCE(212);
       if (lookahead == '"') ADVANCE(1);
-      if (lookahead == '#') ADVANCE(238);
-      if (lookahead == '%') ADVANCE(228);
+      if (lookahead == '#') ADVANCE(255);
+      if (lookahead == '%') ADVANCE(244);
       if (lookahead == '\'') ADVANCE(2);
-      if (lookahead == '.') ADVANCE(190);
-      if (lookahead == '@') ADVANCE(246);
-      if (lookahead == 'A') ADVANCE(116);
-      if (lookahead == 'B') ADVANCE(18);
-      if (lookahead == 'C') ADVANCE(171);
-      if (lookahead == 'D') ADVANCE(133);
-      if (lookahead == 'E') ADVANCE(127);
-      if (lookahead == 'F') ADVANCE(134);
-      if (lookahead == 'H') ADVANCE(81);
-      if (lookahead == 'L') ADVANCE(52);
-      if (lookahead == 'M') ADVANCE(26);
-      if (lookahead == 'O') ADVANCE(178);
-      if (lookahead == 'P') ADVANCE(19);
-      if (lookahead == 'R') ADVANCE(100);
-      if (lookahead == 'S') ADVANCE(69);
-      if (lookahead == 'T') ADVANCE(20);
-      if (lookahead == 'U') ADVANCE(139);
-      if (lookahead == 'W') ADVANCE(101);
-      if (lookahead == '`') ADVANCE(16);
-      if (lookahead == '{') ADVANCE(188);
+      if (lookahead == '.') ADVANCE(206);
+      if (lookahead == '@') ADVANCE(263);
+      if (lookahead == 'A') ADVANCE(119);
+      if (lookahead == 'B') ADVANCE(19);
+      if (lookahead == 'C') ADVANCE(187);
+      if (lookahead == 'D') ADVANCE(141);
+      if (lookahead == 'E') ADVANCE(134);
+      if (lookahead == 'F') ADVANCE(142);
+      if (lookahead == 'H') ADVANCE(84);
+      if (lookahead == 'L') ADVANCE(54);
+      if (lookahead == 'M') ADVANCE(30);
+      if (lookahead == 'O') ADVANCE(192);
+      if (lookahead == 'P') ADVANCE(20);
+      if (lookahead == 'R') ADVANCE(103);
+      if (lookahead == 'S') ADVANCE(70);
+      if (lookahead == 'T') ADVANCE(21);
+      if (lookahead == 'U') ADVANCE(148);
+      if (lookahead == 'W') ADVANCE(104);
+      if (lookahead == '`') ADVANCE(17);
+      if (lookahead == 'f') ADVANCE(25);
+      if (lookahead == 't') ADVANCE(166);
+      if (lookahead == '{') ADVANCE(204);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') SKIP(0)
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(239);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(256);
       END_STATE();
     case 1:
-      if (lookahead == '"') ADVANCE(235);
+      if (lookahead == '"') ADVANCE(252);
       if (lookahead != 0) ADVANCE(1);
       END_STATE();
     case 2:
-      if (lookahead == '\'') ADVANCE(236);
+      if (lookahead == '\'') ADVANCE(253);
       if (lookahead != 0) ADVANCE(2);
       END_STATE();
     case 3:
-      if (lookahead == '+') ADVANCE(193);
+      if (lookahead == '+') ADVANCE(209);
       END_STATE();
     case 4:
-      if (lookahead == '+') ADVANCE(194);
+      if (lookahead == '+') ADVANCE(210);
       END_STATE();
     case 5:
-      if (lookahead == '.') ADVANCE(191);
+      if (lookahead == '.') ADVANCE(207);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') SKIP(5)
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(248);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(257);
       END_STATE();
     case 6:
-      if (lookahead == '.') ADVANCE(192);
+      if (lookahead == '.') ADVANCE(208);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') SKIP(6)
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(240);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(265);
       END_STATE();
     case 7:
-      if (lookahead == 'B') ADVANCE(30);
+      if (lookahead == 'B') ADVANCE(127);
       END_STATE();
     case 8:
-      if (lookahead == 'D') ADVANCE(138);
-      if (lookahead == 'U') ADVANCE(142);
+      if (lookahead == 'B') ADVANCE(32);
       END_STATE();
     case 9:
-      if (lookahead == 'F') ADVANCE(24);
-      if (lookahead == 'S') ADVANCE(102);
+      if (lookahead == 'D') ADVANCE(147);
+      if (lookahead == 'U') ADVANCE(151);
       END_STATE();
     case 10:
-      if (lookahead == 'H') ADVANCE(82);
+      if (lookahead == 'F') ADVANCE(26);
+      if (lookahead == 'S') ADVANCE(105);
       END_STATE();
     case 11:
-      if (lookahead == 'O') ADVANCE(84);
+      if (lookahead == 'H') ADVANCE(85);
       END_STATE();
     case 12:
-      if (lookahead == 'R') ADVANCE(32);
+      if (lookahead == 'O') ADVANCE(86);
       END_STATE();
     case 13:
-      if (lookahead == 'S') ADVANCE(144);
+      if (lookahead == 'R') ADVANCE(35);
       END_STATE();
     case 14:
-      if (lookahead == 'S') ADVANCE(148);
+      if (lookahead == 'S') ADVANCE(153);
       END_STATE();
     case 15:
-      if (lookahead == 'S') ADVANCE(150);
+      if (lookahead == 'S') ADVANCE(157);
       END_STATE();
     case 16:
-      if (lookahead == '`') ADVANCE(237);
-      if (lookahead != 0) ADVANCE(16);
+      if (lookahead == 'S') ADVANCE(159);
       END_STATE();
     case 17:
-      if (lookahead == 'a') ADVANCE(37);
+      if (lookahead == '`') ADVANCE(254);
+      if (lookahead != 0) ADVANCE(17);
       END_STATE();
     case 18:
-      if (lookahead == 'a') ADVANCE(37);
-      if (lookahead == 'o') ADVANCE(158);
+      if (lookahead == 'a') ADVANCE(39);
       END_STATE();
     case 19:
-      if (lookahead == 'a') ADVANCE(45);
-      if (lookahead == 'l') ADVANCE(23);
+      if (lookahead == 'a') ADVANCE(39);
+      if (lookahead == 'o') ADVANCE(170);
       END_STATE();
     case 20:
-      if (lookahead == 'a') ADVANCE(35);
-      if (lookahead == 'h') ADVANCE(80);
-      if (lookahead == 'y') ADVANCE(143);
+      if (lookahead == 'a') ADVANCE(47);
+      if (lookahead == 'l') ADVANCE(24);
       END_STATE();
     case 21:
-      if (lookahead == 'a') ADVANCE(35);
-      if (lookahead == 'y') ADVANCE(146);
+      if (lookahead == 'a') ADVANCE(37);
+      if (lookahead == 'h') ADVANCE(83);
+      if (lookahead == 'y') ADVANCE(152);
       END_STATE();
     case 22:
-      if (lookahead == 'a') ADVANCE(123);
+      if (lookahead == 'a') ADVANCE(37);
+      if (lookahead == 'y') ADVANCE(155);
       END_STATE();
     case 23:
-      if (lookahead == 'a') ADVANCE(185);
+      if (lookahead == 'a') ADVANCE(130);
       END_STATE();
     case 24:
-      if (lookahead == 'a') ADVANCE(121);
+      if (lookahead == 'a') ADVANCE(201);
       END_STATE();
     case 25:
-      if (lookahead == 'a') ADVANCE(40);
+      if (lookahead == 'a') ADVANCE(122);
       END_STATE();
     case 26:
-      if (lookahead == 'a') ADVANCE(156);
+      if (lookahead == 'a') ADVANCE(128);
       END_STATE();
     case 27:
       if (lookahead == 'a') ADVANCE(42);
       END_STATE();
     case 28:
-      if (lookahead == 'a') ADVANCE(145);
+      if (lookahead == 'a') ADVANCE(44);
       END_STATE();
     case 29:
-      if (lookahead == 'a') ADVANCE(91);
-      END_STATE();
-    case 30:
       if (lookahead == 'a') ADVANCE(154);
       END_STATE();
+    case 30:
+      if (lookahead == 'a') ADVANCE(167);
+      END_STATE();
     case 31:
-      if (lookahead == 'a') ADVANCE(38);
+      if (lookahead == 'a') ADVANCE(94);
       END_STATE();
     case 32:
-      if (lookahead == 'a') ADVANCE(47);
+      if (lookahead == 'a') ADVANCE(165);
       END_STATE();
     case 33:
-      if (lookahead == 'a') ADVANCE(175);
+      if (lookahead == 'a') ADVANCE(40);
       END_STATE();
     case 34:
-      if (lookahead == 'a') ADVANCE(41);
+      if (lookahead == 'a') ADVANCE(190);
       END_STATE();
     case 35:
-      if (lookahead == 'b') ADVANCE(212);
+      if (lookahead == 'a') ADVANCE(49);
       END_STATE();
     case 36:
-      if (lookahead == 'b') ADVANCE(31);
+      if (lookahead == 'a') ADVANCE(43);
       END_STATE();
     case 37:
-      if (lookahead == 'c') ADVANCE(112);
+      if (lookahead == 'b') ADVANCE(228);
       END_STATE();
     case 38:
-      if (lookahead == 'c') ADVANCE(113);
+      if (lookahead == 'b') ADVANCE(33);
       END_STATE();
     case 39:
-      if (lookahead == 'c') ADVANCE(28);
+      if (lookahead == 'c') ADVANCE(117);
       END_STATE();
     case 40:
-      if (lookahead == 'c') ADVANCE(58);
+      if (lookahead == 'c') ADVANCE(118);
       END_STATE();
     case 41:
-      if (lookahead == 'c') ADVANCE(62);
+      if (lookahead == 'c') ADVANCE(29);
       END_STATE();
     case 42:
-      if (lookahead == 'c') ADVANCE(107);
+      if (lookahead == 'c') ADVANCE(61);
       END_STATE();
     case 43:
-      if (lookahead == 'd') ADVANCE(223);
+      if (lookahead == 'c') ADVANCE(65);
       END_STATE();
     case 44:
-      if (lookahead == 'd') ADVANCE(220);
+      if (lookahead == 'c') ADVANCE(111);
       END_STATE();
     case 45:
-      if (lookahead == 'd') ADVANCE(50);
-      if (lookahead == 'g') ADVANCE(55);
+      if (lookahead == 'd') ADVANCE(239);
       END_STATE();
     case 46:
-      if (lookahead == 'd') ADVANCE(53);
+      if (lookahead == 'd') ADVANCE(236);
       END_STATE();
     case 47:
-      if (lookahead == 'd') ADVANCE(103);
+      if (lookahead == 'd') ADVANCE(52);
+      if (lookahead == 'g') ADVANCE(57);
       END_STATE();
     case 48:
-      if (lookahead == 'd') ADVANCE(172);
-      if (lookahead == 'n') ADVANCE(49);
+      if (lookahead == 'd') ADVANCE(55);
       END_STATE();
     case 49:
-      if (lookahead == 'd') ADVANCE(137);
-      END_STATE();
-    case 50:
       if (lookahead == 'd') ADVANCE(106);
       END_STATE();
+    case 50:
+      if (lookahead == 'd') ADVANCE(185);
+      if (lookahead == 'n') ADVANCE(51);
+      END_STATE();
     case 51:
-      if (lookahead == 'd') ADVANCE(71);
+      if (lookahead == 'd') ADVANCE(145);
       END_STATE();
     case 52:
-      if (lookahead == 'e') ADVANCE(86);
-      if (lookahead == 'i') ADVANCE(131);
-      if (lookahead == 'o') ADVANCE(136);
+      if (lookahead == 'd') ADVANCE(108);
       END_STATE();
     case 53:
-      if (lookahead == 'e') ADVANCE(199);
+      if (lookahead == 'd') ADVANCE(76);
       END_STATE();
     case 54:
-      if (lookahead == 'e') ADVANCE(10);
+      if (lookahead == 'e') ADVANCE(88);
+      if (lookahead == 'i') ADVANCE(140);
+      if (lookahead == 'o') ADVANCE(144);
       END_STATE();
     case 55:
-      if (lookahead == 'e') ADVANCE(8);
+      if (lookahead == 'e') ADVANCE(215);
       END_STATE();
     case 56:
-      if (lookahead == 'e') ADVANCE(204);
+      if (lookahead == 'e') ADVANCE(11);
       END_STATE();
     case 57:
-      if (lookahead == 'e') ADVANCE(204);
-      if (lookahead == 'i') ADVANCE(128);
+      if (lookahead == 'e') ADVANCE(9);
       END_STATE();
     case 58:
-      if (lookahead == 'e') ADVANCE(211);
+      if (lookahead == 'e') ADVANCE(220);
       END_STATE();
     case 59:
-      if (lookahead == 'e') ADVANCE(226);
+      if (lookahead == 'e') ADVANCE(220);
+      if (lookahead == 'i') ADVANCE(135);
       END_STATE();
     case 60:
-      if (lookahead == 'e') ADVANCE(208);
+      if (lookahead == 'e') ADVANCE(268);
       END_STATE();
     case 61:
-      if (lookahead == 'e') ADVANCE(218);
+      if (lookahead == 'e') ADVANCE(227);
       END_STATE();
     case 62:
-      if (lookahead == 'e') ADVANCE(205);
+      if (lookahead == 'e') ADVANCE(242);
       END_STATE();
     case 63:
-      if (lookahead == 'e') ADVANCE(219);
+      if (lookahead == 'e') ADVANCE(224);
       END_STATE();
     case 64:
       if (lookahead == 'e') ADVANCE(234);
       END_STATE();
     case 65:
-      if (lookahead == 'e') ADVANCE(118);
-      if (lookahead == 'o') ADVANCE(180);
+      if (lookahead == 'e') ADVANCE(221);
       END_STATE();
     case 66:
-      if (lookahead == 'e') ADVANCE(85);
+      if (lookahead == 'e') ADVANCE(235);
       END_STATE();
     case 67:
-      if (lookahead == 'e') ADVANCE(151);
+      if (lookahead == 'e') ADVANCE(250);
       END_STATE();
     case 68:
-      if (lookahead == 'e') ADVANCE(43);
+      if (lookahead == 'e') ADVANCE(87);
       END_STATE();
     case 69:
-      if (lookahead == 'e') ADVANCE(163);
-      if (lookahead == 'h') ADVANCE(65);
-      if (lookahead == 'l') ADVANCE(76);
-      if (lookahead == 'p') ADVANCE(25);
+      if (lookahead == 'e') ADVANCE(124);
+      if (lookahead == 'o') ADVANCE(196);
       END_STATE();
     case 70:
-      if (lookahead == 'e') ADVANCE(163);
-      if (lookahead == 'h') ADVANCE(135);
-      if (lookahead == 'l') ADVANCE(76);
-      if (lookahead == 'p') ADVANCE(25);
-      END_STATE();
-    case 71:
-      if (lookahead == 'e') ADVANCE(152);
-      END_STATE();
-    case 72:
-      if (lookahead == 'e') ADVANCE(44);
-      END_STATE();
-    case 73:
-      if (lookahead == 'e') ADVANCE(141);
-      END_STATE();
-    case 74:
-      if (lookahead == 'e') ADVANCE(157);
-      END_STATE();
-    case 75:
-      if (lookahead == 'e') ADVANCE(153);
-      END_STATE();
-    case 76:
-      if (lookahead == 'e') ADVANCE(73);
-      END_STATE();
-    case 77:
-      if (lookahead == 'e') ADVANCE(170);
-      END_STATE();
-    case 78:
-      if (lookahead == 'e') ADVANCE(68);
-      END_STATE();
-    case 79:
-      if (lookahead == 'e') ADVANCE(72);
-      END_STATE();
-    case 80:
-      if (lookahead == 'e') ADVANCE(122);
-      END_STATE();
-    case 81:
-      if (lookahead == 'e') ADVANCE(110);
-      if (lookahead == 'i') ADVANCE(46);
-      END_STATE();
-    case 82:
-      if (lookahead == 'e') ADVANCE(111);
-      END_STATE();
-    case 83:
-      if (lookahead == 'f') ADVANCE(161);
-      END_STATE();
-    case 84:
-      if (lookahead == 'f') ADVANCE(83);
-      END_STATE();
-    case 85:
-      if (lookahead == 'f') ADVANCE(165);
-      END_STATE();
-    case 86:
-      if (lookahead == 'f') ADVANCE(165);
-      if (lookahead == 't') ADVANCE(176);
-      END_STATE();
-    case 87:
-      if (lookahead == 'g') ADVANCE(96);
-      END_STATE();
-    case 88:
-      if (lookahead == 'g') ADVANCE(225);
-      END_STATE();
-    case 89:
-      if (lookahead == 'g') ADVANCE(222);
-      END_STATE();
-    case 90:
-      if (lookahead == 'g') ADVANCE(105);
-      END_STATE();
-    case 91:
-      if (lookahead == 'g') ADVANCE(55);
-      END_STATE();
-    case 92:
-      if (lookahead == 'g') ADVANCE(97);
-      END_STATE();
-    case 93:
-      if (lookahead == 'g') ADVANCE(14);
-      END_STATE();
-    case 94:
-      if (lookahead == 'g') ADVANCE(98);
-      END_STATE();
-    case 95:
-      if (lookahead == 'h') ADVANCE(229);
-      END_STATE();
-    case 96:
-      if (lookahead == 'h') ADVANCE(166);
-      END_STATE();
-    case 97:
-      if (lookahead == 'h') ADVANCE(167);
-      END_STATE();
-    case 98:
-      if (lookahead == 'h') ADVANCE(169);
-      END_STATE();
-    case 99:
-      if (lookahead == 'i') ADVANCE(46);
-      END_STATE();
-    case 100:
-      if (lookahead == 'i') ADVANCE(87);
-      END_STATE();
-    case 101:
-      if (lookahead == 'i') ADVANCE(48);
-      END_STATE();
-    case 102:
-      if (lookahead == 'i') ADVANCE(186);
-      END_STATE();
-    case 103:
-      if (lookahead == 'i') ADVANCE(177);
-      END_STATE();
-    case 104:
-      if (lookahead == 'i') ADVANCE(117);
-      END_STATE();
-    case 105:
-      if (lookahead == 'i') ADVANCE(125);
-      END_STATE();
-    case 106:
-      if (lookahead == 'i') ADVANCE(129);
-      END_STATE();
-    case 107:
-      if (lookahead == 'i') ADVANCE(130);
-      END_STATE();
-    case 108:
-      if (lookahead == 'i') ADVANCE(187);
-      END_STATE();
-    case 109:
-      if (lookahead == 'i') ADVANCE(119);
-      END_STATE();
-    case 110:
-      if (lookahead == 'i') ADVANCE(92);
-      END_STATE();
-    case 111:
-      if (lookahead == 'i') ADVANCE(94);
-      END_STATE();
-    case 112:
-      if (lookahead == 'k') ADVANCE(160);
-      END_STATE();
-    case 113:
-      if (lookahead == 'k') ADVANCE(15);
-      END_STATE();
-    case 114:
-      if (lookahead == 'l') ADVANCE(216);
-      END_STATE();
-    case 115:
-      if (lookahead == 'l') ADVANCE(232);
-      END_STATE();
-    case 116:
-      if (lookahead == 'l') ADVANCE(162);
-      END_STATE();
-    case 117:
-      if (lookahead == 'l') ADVANCE(184);
-      END_STATE();
-    case 118:
-      if (lookahead == 'l') ADVANCE(114);
-      END_STATE();
-    case 119:
-      if (lookahead == 'l') ADVANCE(115);
-      END_STATE();
-    case 120:
-      if (lookahead == 'l') ADVANCE(4);
-      END_STATE();
-    case 121:
-      if (lookahead == 'm') ADVANCE(104);
-      END_STATE();
-    case 122:
-      if (lookahead == 'm') ADVANCE(59);
-      END_STATE();
-    case 123:
-      if (lookahead == 'm') ADVANCE(74);
-      END_STATE();
-    case 124:
-      if (lookahead == 'n') ADVANCE(206);
-      END_STATE();
-    case 125:
-      if (lookahead == 'n') ADVANCE(231);
-      END_STATE();
-    case 126:
-      if (lookahead == 'n') ADVANCE(215);
-      END_STATE();
-    case 127:
-      if (lookahead == 'n') ADVANCE(173);
-      if (lookahead == 's') ADVANCE(39);
-      END_STATE();
-    case 128:
-      if (lookahead == 'n') ADVANCE(93);
-      END_STATE();
-    case 129:
-      if (lookahead == 'n') ADVANCE(88);
-      END_STATE();
-    case 130:
-      if (lookahead == 'n') ADVANCE(89);
-      END_STATE();
-    case 131:
-      if (lookahead == 'n') ADVANCE(54);
-      END_STATE();
-    case 132:
-      if (lookahead == 'n') ADVANCE(164);
-      END_STATE();
-    case 133:
-      if (lookahead == 'o') ADVANCE(182);
-      END_STATE();
-    case 134:
-      if (lookahead == 'o') ADVANCE(132);
-      if (lookahead == 'r') ADVANCE(22);
-      END_STATE();
-    case 135:
-      if (lookahead == 'o') ADVANCE(180);
-      END_STATE();
-    case 136:
-      if (lookahead == 'o') ADVANCE(140);
-      END_STATE();
-    case 137:
-      if (lookahead == 'o') ADVANCE(181);
-      END_STATE();
-    case 138:
-      if (lookahead == 'o') ADVANCE(183);
-      END_STATE();
-    case 139:
-      if (lookahead == 'p') ADVANCE(213);
-      END_STATE();
-    case 140:
-      if (lookahead == 'p') ADVANCE(11);
-      END_STATE();
-    case 141:
-      if (lookahead == 'p') ADVANCE(203);
-      END_STATE();
-    case 142:
-      if (lookahead == 'p') ADVANCE(214);
-      END_STATE();
-    case 143:
-      if (lookahead == 'p') ADVANCE(57);
-      END_STATE();
-    case 144:
+      if (lookahead == 'e') ADVANCE(177);
+      if (lookahead == 'h') ADVANCE(69);
+      if (lookahead == 'l') ADVANCE(77);
       if (lookahead == 'p') ADVANCE(27);
       END_STATE();
+    case 71:
+      if (lookahead == 'e') ADVANCE(177);
+      if (lookahead == 'h') ADVANCE(143);
+      if (lookahead == 'l') ADVANCE(77);
+      if (lookahead == 'p') ADVANCE(27);
+      END_STATE();
+    case 72:
+      if (lookahead == 'e') ADVANCE(45);
+      END_STATE();
+    case 73:
+      if (lookahead == 'e') ADVANCE(46);
+      END_STATE();
+    case 74:
+      if (lookahead == 'e') ADVANCE(150);
+      END_STATE();
+    case 75:
+      if (lookahead == 'e') ADVANCE(161);
+      END_STATE();
+    case 76:
+      if (lookahead == 'e') ADVANCE(162);
+      END_STATE();
+    case 77:
+      if (lookahead == 'e') ADVANCE(74);
+      END_STATE();
+    case 78:
+      if (lookahead == 'e') ADVANCE(169);
+      END_STATE();
+    case 79:
+      if (lookahead == 'e') ADVANCE(164);
+      END_STATE();
+    case 80:
+      if (lookahead == 'e') ADVANCE(184);
+      END_STATE();
+    case 81:
+      if (lookahead == 'e') ADVANCE(72);
+      END_STATE();
+    case 82:
+      if (lookahead == 'e') ADVANCE(73);
+      END_STATE();
+    case 83:
+      if (lookahead == 'e') ADVANCE(129);
+      END_STATE();
+    case 84:
+      if (lookahead == 'e') ADVANCE(114);
+      if (lookahead == 'i') ADVANCE(48);
+      END_STATE();
+    case 85:
+      if (lookahead == 'e') ADVANCE(115);
+      END_STATE();
+    case 86:
+      if (lookahead == 'f') ADVANCE(89);
+      END_STATE();
+    case 87:
+      if (lookahead == 'f') ADVANCE(179);
+      END_STATE();
+    case 88:
+      if (lookahead == 'f') ADVANCE(179);
+      if (lookahead == 't') ADVANCE(191);
+      END_STATE();
+    case 89:
+      if (lookahead == 'f') ADVANCE(175);
+      END_STATE();
+    case 90:
+      if (lookahead == 'g') ADVANCE(99);
+      END_STATE();
+    case 91:
+      if (lookahead == 'g') ADVANCE(241);
+      END_STATE();
+    case 92:
+      if (lookahead == 'g') ADVANCE(238);
+      END_STATE();
+    case 93:
+      if (lookahead == 'g') ADVANCE(107);
+      END_STATE();
+    case 94:
+      if (lookahead == 'g') ADVANCE(57);
+      END_STATE();
+    case 95:
+      if (lookahead == 'g') ADVANCE(100);
+      END_STATE();
+    case 96:
+      if (lookahead == 'g') ADVANCE(15);
+      END_STATE();
+    case 97:
+      if (lookahead == 'g') ADVANCE(101);
+      END_STATE();
+    case 98:
+      if (lookahead == 'h') ADVANCE(245);
+      END_STATE();
+    case 99:
+      if (lookahead == 'h') ADVANCE(180);
+      END_STATE();
+    case 100:
+      if (lookahead == 'h') ADVANCE(181);
+      END_STATE();
+    case 101:
+      if (lookahead == 'h') ADVANCE(183);
+      END_STATE();
+    case 102:
+      if (lookahead == 'i') ADVANCE(48);
+      END_STATE();
+    case 103:
+      if (lookahead == 'i') ADVANCE(90);
+      END_STATE();
+    case 104:
+      if (lookahead == 'i') ADVANCE(50);
+      END_STATE();
+    case 105:
+      if (lookahead == 'i') ADVANCE(202);
+      END_STATE();
+    case 106:
+      if (lookahead == 'i') ADVANCE(193);
+      END_STATE();
+    case 107:
+      if (lookahead == 'i') ADVANCE(132);
+      END_STATE();
+    case 108:
+      if (lookahead == 'i') ADVANCE(137);
+      END_STATE();
+    case 109:
+      if (lookahead == 'i') ADVANCE(123);
+      END_STATE();
+    case 110:
+      if (lookahead == 'i') ADVANCE(136);
+      END_STATE();
+    case 111:
+      if (lookahead == 'i') ADVANCE(139);
+      END_STATE();
+    case 112:
+      if (lookahead == 'i') ADVANCE(203);
+      END_STATE();
+    case 113:
+      if (lookahead == 'i') ADVANCE(125);
+      END_STATE();
+    case 114:
+      if (lookahead == 'i') ADVANCE(95);
+      END_STATE();
+    case 115:
+      if (lookahead == 'i') ADVANCE(97);
+      END_STATE();
+    case 116:
+      if (lookahead == 'k') ADVANCE(251);
+      END_STATE();
+    case 117:
+      if (lookahead == 'k') ADVANCE(173);
+      END_STATE();
+    case 118:
+      if (lookahead == 'k') ADVANCE(16);
+      END_STATE();
+    case 119:
+      if (lookahead == 'l') ADVANCE(176);
+      END_STATE();
+    case 120:
+      if (lookahead == 'l') ADVANCE(232);
+      END_STATE();
+    case 121:
+      if (lookahead == 'l') ADVANCE(248);
+      END_STATE();
+    case 122:
+      if (lookahead == 'l') ADVANCE(174);
+      END_STATE();
+    case 123:
+      if (lookahead == 'l') ADVANCE(200);
+      END_STATE();
+    case 124:
+      if (lookahead == 'l') ADVANCE(120);
+      END_STATE();
+    case 125:
+      if (lookahead == 'l') ADVANCE(121);
+      END_STATE();
+    case 126:
+      if (lookahead == 'l') ADVANCE(4);
+      END_STATE();
+    case 127:
+      if (lookahead == 'l') ADVANCE(110);
+      END_STATE();
+    case 128:
+      if (lookahead == 'm') ADVANCE(109);
+      END_STATE();
+    case 129:
+      if (lookahead == 'm') ADVANCE(62);
+      END_STATE();
+    case 130:
+      if (lookahead == 'm') ADVANCE(78);
+      END_STATE();
+    case 131:
+      if (lookahead == 'n') ADVANCE(222);
+      END_STATE();
+    case 132:
+      if (lookahead == 'n') ADVANCE(247);
+      END_STATE();
+    case 133:
+      if (lookahead == 'n') ADVANCE(231);
+      END_STATE();
+    case 134:
+      if (lookahead == 'n') ADVANCE(188);
+      if (lookahead == 's') ADVANCE(41);
+      END_STATE();
+    case 135:
+      if (lookahead == 'n') ADVANCE(96);
+      END_STATE();
+    case 136:
+      if (lookahead == 'n') ADVANCE(116);
+      END_STATE();
+    case 137:
+      if (lookahead == 'n') ADVANCE(91);
+      END_STATE();
+    case 138:
+      if (lookahead == 'n') ADVANCE(178);
+      END_STATE();
+    case 139:
+      if (lookahead == 'n') ADVANCE(92);
+      END_STATE();
+    case 140:
+      if (lookahead == 'n') ADVANCE(56);
+      END_STATE();
+    case 141:
+      if (lookahead == 'o') ADVANCE(198);
+      END_STATE();
+    case 142:
+      if (lookahead == 'o') ADVANCE(138);
+      if (lookahead == 'r') ADVANCE(23);
+      END_STATE();
+    case 143:
+      if (lookahead == 'o') ADVANCE(196);
+      END_STATE();
+    case 144:
+      if (lookahead == 'o') ADVANCE(149);
+      END_STATE();
     case 145:
-      if (lookahead == 'p') ADVANCE(60);
+      if (lookahead == 'o') ADVANCE(197);
       END_STATE();
     case 146:
-      if (lookahead == 'p') ADVANCE(56);
+      if (lookahead == 'o') ADVANCE(163);
       END_STATE();
     case 147:
-      if (lookahead == 'p') ADVANCE(179);
+      if (lookahead == 'o') ADVANCE(199);
       END_STATE();
     case 148:
-      if (lookahead == 'p') ADVANCE(78);
+      if (lookahead == 'p') ADVANCE(229);
       END_STATE();
     case 149:
-      if (lookahead == 'p') ADVANCE(34);
+      if (lookahead == 'p') ADVANCE(12);
       END_STATE();
     case 150:
-      if (lookahead == 'p') ADVANCE(79);
+      if (lookahead == 'p') ADVANCE(219);
       END_STATE();
     case 151:
-      if (lookahead == 'r') ADVANCE(207);
+      if (lookahead == 'p') ADVANCE(230);
       END_STATE();
     case 152:
-      if (lookahead == 'r') ADVANCE(12);
+      if (lookahead == 'p') ADVANCE(59);
       END_STATE();
     case 153:
-      if (lookahead == 'r') ADVANCE(13);
+      if (lookahead == 'p') ADVANCE(28);
       END_STATE();
     case 154:
-      if (lookahead == 'r') ADVANCE(233);
+      if (lookahead == 'p') ADVANCE(63);
       END_STATE();
     case 155:
-      if (lookahead == 'r') ADVANCE(120);
+      if (lookahead == 'p') ADVANCE(58);
       END_STATE();
     case 156:
-      if (lookahead == 'r') ADVANCE(90);
+      if (lookahead == 'p') ADVANCE(195);
       END_STATE();
     case 157:
-      if (lookahead == 'r') ADVANCE(33);
+      if (lookahead == 'p') ADVANCE(81);
       END_STATE();
     case 158:
-      if (lookahead == 'r') ADVANCE(51);
+      if (lookahead == 'p') ADVANCE(36);
       END_STATE();
     case 159:
-      if (lookahead == 's') ADVANCE(230);
+      if (lookahead == 'p') ADVANCE(82);
       END_STATE();
     case 160:
-      if (lookahead == 's') ADVANCE(149);
+      if (lookahead == 'r') ADVANCE(172);
       END_STATE();
     case 161:
-      if (lookahead == 's') ADVANCE(77);
+      if (lookahead == 'r') ADVANCE(223);
       END_STATE();
     case 162:
-      if (lookahead == 't') ADVANCE(3);
+      if (lookahead == 'r') ADVANCE(13);
       END_STATE();
     case 163:
-      if (lookahead == 't') ADVANCE(202);
+      if (lookahead == 'r') ADVANCE(7);
       END_STATE();
     case 164:
-      if (lookahead == 't') ADVANCE(9);
+      if (lookahead == 'r') ADVANCE(14);
       END_STATE();
     case 165:
-      if (lookahead == 't') ADVANCE(209);
+      if (lookahead == 'r') ADVANCE(249);
       END_STATE();
     case 166:
-      if (lookahead == 't') ADVANCE(210);
+      if (lookahead == 'r') ADVANCE(194);
       END_STATE();
     case 167:
-      if (lookahead == 't') ADVANCE(221);
+      if (lookahead == 'r') ADVANCE(93);
       END_STATE();
     case 168:
-      if (lookahead == 't') ADVANCE(201);
+      if (lookahead == 'r') ADVANCE(126);
       END_STATE();
     case 169:
-      if (lookahead == 't') ADVANCE(224);
+      if (lookahead == 'r') ADVANCE(34);
       END_STATE();
     case 170:
-      if (lookahead == 't') ADVANCE(227);
+      if (lookahead == 'r') ADVANCE(53);
       END_STATE();
     case 171:
-      if (lookahead == 't') ADVANCE(155);
+      if (lookahead == 's') ADVANCE(246);
       END_STATE();
     case 172:
-      if (lookahead == 't') ADVANCE(95);
+      if (lookahead == 's') ADVANCE(146);
       END_STATE();
     case 173:
-      if (lookahead == 't') ADVANCE(67);
+      if (lookahead == 's') ADVANCE(158);
       END_STATE();
     case 174:
-      if (lookahead == 't') ADVANCE(147);
+      if (lookahead == 's') ADVANCE(60);
       END_STATE();
     case 175:
-      if (lookahead == 't') ADVANCE(63);
+      if (lookahead == 's') ADVANCE(80);
       END_STATE();
     case 176:
-      if (lookahead == 't') ADVANCE(75);
+      if (lookahead == 't') ADVANCE(3);
       END_STATE();
     case 177:
-      if (lookahead == 'u') ADVANCE(159);
+      if (lookahead == 't') ADVANCE(218);
       END_STATE();
     case 178:
-      if (lookahead == 'u') ADVANCE(174);
+      if (lookahead == 't') ADVANCE(10);
       END_STATE();
     case 179:
-      if (lookahead == 'u') ADVANCE(168);
+      if (lookahead == 't') ADVANCE(225);
       END_STATE();
     case 180:
-      if (lookahead == 'w') ADVANCE(200);
+      if (lookahead == 't') ADVANCE(226);
       END_STATE();
     case 181:
-      if (lookahead == 'w') ADVANCE(7);
+      if (lookahead == 't') ADVANCE(237);
       END_STATE();
     case 182:
-      if (lookahead == 'w') ADVANCE(124);
+      if (lookahead == 't') ADVANCE(217);
       END_STATE();
     case 183:
-      if (lookahead == 'w') ADVANCE(126);
+      if (lookahead == 't') ADVANCE(240);
       END_STATE();
     case 184:
-      if (lookahead == 'y') ADVANCE(217);
+      if (lookahead == 't') ADVANCE(243);
       END_STATE();
     case 185:
-      if (lookahead == 'y') ADVANCE(36);
+      if (lookahead == 't') ADVANCE(98);
       END_STATE();
     case 186:
-      if (lookahead == 'z') ADVANCE(61);
+      if (lookahead == 't') ADVANCE(168);
       END_STATE();
     case 187:
-      if (lookahead == 'z') ADVANCE(64);
+      if (lookahead == 't') ADVANCE(168);
+      if (lookahead == 'u') ADVANCE(160);
       END_STATE();
     case 188:
-      if (lookahead == '}') ADVANCE(244);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(188);
+      if (lookahead == 't') ADVANCE(75);
       END_STATE();
     case 189:
+      if (lookahead == 't') ADVANCE(156);
+      END_STATE();
+    case 190:
+      if (lookahead == 't') ADVANCE(66);
+      END_STATE();
+    case 191:
+      if (lookahead == 't') ADVANCE(79);
+      END_STATE();
+    case 192:
+      if (lookahead == 'u') ADVANCE(189);
+      END_STATE();
+    case 193:
+      if (lookahead == 'u') ADVANCE(171);
+      END_STATE();
+    case 194:
+      if (lookahead == 'u') ADVANCE(60);
+      END_STATE();
+    case 195:
+      if (lookahead == 'u') ADVANCE(182);
+      END_STATE();
+    case 196:
+      if (lookahead == 'w') ADVANCE(216);
+      END_STATE();
+    case 197:
+      if (lookahead == 'w') ADVANCE(8);
+      END_STATE();
+    case 198:
+      if (lookahead == 'w') ADVANCE(131);
+      END_STATE();
+    case 199:
+      if (lookahead == 'w') ADVANCE(133);
+      END_STATE();
+    case 200:
+      if (lookahead == 'y') ADVANCE(233);
+      END_STATE();
+    case 201:
+      if (lookahead == 'y') ADVANCE(38);
+      END_STATE();
+    case 202:
+      if (lookahead == 'z') ADVANCE(64);
+      END_STATE();
+    case 203:
+      if (lookahead == 'z') ADVANCE(67);
+      END_STATE();
+    case 204:
+      if (lookahead == '}') ADVANCE(261);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(204);
+      END_STATE();
+    case 205:
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') SKIP(189)
+          lookahead == ' ') SKIP(205)
       if (lookahead == '%' ||
           ('-' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(245);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(262);
       END_STATE();
-    case 190:
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(241);
+    case 206:
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(258);
       END_STATE();
-    case 191:
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(249);
+    case 207:
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(259);
       END_STATE();
-    case 192:
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(242);
+    case 208:
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(266);
       END_STATE();
-    case 193:
-      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(198);
+    case 209:
+      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(214);
       END_STATE();
-    case 194:
-      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(197);
+    case 210:
+      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(213);
       END_STATE();
-    case 195:
-      if (eof) ADVANCE(196);
+    case 211:
+      if (eof) ADVANCE(212);
       if (lookahead == '"') ADVANCE(1);
-      if (lookahead == '#') ADVANCE(238);
+      if (lookahead == '#') ADVANCE(255);
       if (lookahead == '\'') ADVANCE(2);
-      if (lookahead == '@') ADVANCE(246);
-      if (lookahead == 'A') ADVANCE(116);
-      if (lookahead == 'B') ADVANCE(17);
-      if (lookahead == 'C') ADVANCE(171);
-      if (lookahead == 'D') ADVANCE(133);
-      if (lookahead == 'E') ADVANCE(127);
-      if (lookahead == 'H') ADVANCE(99);
-      if (lookahead == 'L') ADVANCE(66);
-      if (lookahead == 'O') ADVANCE(178);
-      if (lookahead == 'P') ADVANCE(29);
-      if (lookahead == 'R') ADVANCE(100);
-      if (lookahead == 'S') ADVANCE(70);
-      if (lookahead == 'T') ADVANCE(21);
-      if (lookahead == 'U') ADVANCE(139);
-      if (lookahead == '`') ADVANCE(16);
+      if (lookahead == '@') ADVANCE(263);
+      if (lookahead == 'A') ADVANCE(119);
+      if (lookahead == 'B') ADVANCE(18);
+      if (lookahead == 'C') ADVANCE(186);
+      if (lookahead == 'D') ADVANCE(141);
+      if (lookahead == 'E') ADVANCE(134);
+      if (lookahead == 'H') ADVANCE(102);
+      if (lookahead == 'L') ADVANCE(68);
+      if (lookahead == 'O') ADVANCE(192);
+      if (lookahead == 'P') ADVANCE(31);
+      if (lookahead == 'R') ADVANCE(103);
+      if (lookahead == 'S') ADVANCE(71);
+      if (lookahead == 'T') ADVANCE(22);
+      if (lookahead == 'U') ADVANCE(148);
+      if (lookahead == '`') ADVANCE(17);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') SKIP(195)
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(243);
-      END_STATE();
-    case 196:
-      ACCEPT_TOKEN(ts_builtin_sym_end);
-      END_STATE();
-    case 197:
-      ACCEPT_TOKEN(sym_control);
-      END_STATE();
-    case 198:
-      ACCEPT_TOKEN(sym_alt);
-      END_STATE();
-    case 199:
-      ACCEPT_TOKEN(anon_sym_Hide);
-      END_STATE();
-    case 200:
-      ACCEPT_TOKEN(anon_sym_Show);
-      END_STATE();
-    case 201:
-      ACCEPT_TOKEN(anon_sym_Output);
-      END_STATE();
-    case 202:
-      ACCEPT_TOKEN(anon_sym_Set);
-      END_STATE();
-    case 203:
-      ACCEPT_TOKEN(anon_sym_Sleep);
-      END_STATE();
-    case 204:
-      ACCEPT_TOKEN(anon_sym_Type);
-      END_STATE();
-    case 205:
-      ACCEPT_TOKEN(anon_sym_Backspace);
-      END_STATE();
-    case 206:
-      ACCEPT_TOKEN(anon_sym_Down);
-      END_STATE();
-    case 207:
-      ACCEPT_TOKEN(anon_sym_Enter);
-      END_STATE();
-    case 208:
-      ACCEPT_TOKEN(anon_sym_Escape);
-      END_STATE();
-    case 209:
-      ACCEPT_TOKEN(anon_sym_Left);
-      END_STATE();
-    case 210:
-      ACCEPT_TOKEN(anon_sym_Right);
-      END_STATE();
-    case 211:
-      ACCEPT_TOKEN(anon_sym_Space);
+          lookahead == ' ') SKIP(211)
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(260);
       END_STATE();
     case 212:
-      ACCEPT_TOKEN(anon_sym_Tab);
+      ACCEPT_TOKEN(ts_builtin_sym_end);
       END_STATE();
     case 213:
-      ACCEPT_TOKEN(anon_sym_Up);
+      ACCEPT_TOKEN(sym_control);
       END_STATE();
     case 214:
-      ACCEPT_TOKEN(anon_sym_PageUp);
+      ACCEPT_TOKEN(sym_alt);
       END_STATE();
     case 215:
-      ACCEPT_TOKEN(anon_sym_PageDown);
+      ACCEPT_TOKEN(anon_sym_Hide);
       END_STATE();
     case 216:
-      ACCEPT_TOKEN(anon_sym_Shell);
+      ACCEPT_TOKEN(anon_sym_Show);
       END_STATE();
     case 217:
-      ACCEPT_TOKEN(anon_sym_FontFamily);
+      ACCEPT_TOKEN(anon_sym_Output);
       END_STATE();
     case 218:
-      ACCEPT_TOKEN(anon_sym_FontSize);
+      ACCEPT_TOKEN(anon_sym_Set);
       END_STATE();
     case 219:
-      ACCEPT_TOKEN(anon_sym_Framerate);
+      ACCEPT_TOKEN(anon_sym_Sleep);
       END_STATE();
     case 220:
-      ACCEPT_TOKEN(anon_sym_PlaybackSpeed);
+      ACCEPT_TOKEN(anon_sym_Type);
       END_STATE();
     case 221:
-      ACCEPT_TOKEN(anon_sym_Height);
+      ACCEPT_TOKEN(anon_sym_Backspace);
       END_STATE();
     case 222:
-      ACCEPT_TOKEN(anon_sym_LetterSpacing);
+      ACCEPT_TOKEN(anon_sym_Down);
       END_STATE();
     case 223:
-      ACCEPT_TOKEN(anon_sym_TypingSpeed);
+      ACCEPT_TOKEN(anon_sym_Enter);
       END_STATE();
     case 224:
-      ACCEPT_TOKEN(anon_sym_LineHeight);
+      ACCEPT_TOKEN(anon_sym_Escape);
       END_STATE();
     case 225:
-      ACCEPT_TOKEN(anon_sym_Padding);
+      ACCEPT_TOKEN(anon_sym_Left);
       END_STATE();
     case 226:
-      ACCEPT_TOKEN(anon_sym_Theme);
+      ACCEPT_TOKEN(anon_sym_Right);
       END_STATE();
     case 227:
-      ACCEPT_TOKEN(anon_sym_LoopOffset);
+      ACCEPT_TOKEN(anon_sym_Space);
       END_STATE();
     case 228:
-      ACCEPT_TOKEN(anon_sym_PERCENT);
+      ACCEPT_TOKEN(anon_sym_Tab);
       END_STATE();
     case 229:
-      ACCEPT_TOKEN(anon_sym_Width);
+      ACCEPT_TOKEN(anon_sym_Up);
       END_STATE();
     case 230:
-      ACCEPT_TOKEN(anon_sym_BorderRadius);
+      ACCEPT_TOKEN(anon_sym_PageUp);
       END_STATE();
     case 231:
-      ACCEPT_TOKEN(anon_sym_Margin);
-      if (lookahead == 'F') ADVANCE(109);
+      ACCEPT_TOKEN(anon_sym_PageDown);
       END_STATE();
     case 232:
-      ACCEPT_TOKEN(anon_sym_MarginFill);
+      ACCEPT_TOKEN(anon_sym_Shell);
       END_STATE();
     case 233:
-      ACCEPT_TOKEN(anon_sym_WindowBar);
-      if (lookahead == 'S') ADVANCE(108);
+      ACCEPT_TOKEN(anon_sym_FontFamily);
       END_STATE();
     case 234:
-      ACCEPT_TOKEN(anon_sym_WindowBarSize);
+      ACCEPT_TOKEN(anon_sym_FontSize);
       END_STATE();
     case 235:
-      ACCEPT_TOKEN(aux_sym_string_token1);
+      ACCEPT_TOKEN(anon_sym_Framerate);
       END_STATE();
     case 236:
-      ACCEPT_TOKEN(aux_sym_string_token2);
+      ACCEPT_TOKEN(anon_sym_PlaybackSpeed);
       END_STATE();
     case 237:
-      ACCEPT_TOKEN(aux_sym_string_token3);
+      ACCEPT_TOKEN(anon_sym_Height);
       END_STATE();
     case 238:
-      ACCEPT_TOKEN(sym_comment);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(238);
+      ACCEPT_TOKEN(anon_sym_LetterSpacing);
       END_STATE();
     case 239:
-      ACCEPT_TOKEN(sym_float);
-      if (lookahead == '.') ADVANCE(190);
-      if (lookahead == 'm') ADVANCE(250);
-      if (lookahead == 's') ADVANCE(247);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(239);
+      ACCEPT_TOKEN(anon_sym_TypingSpeed);
       END_STATE();
     case 240:
-      ACCEPT_TOKEN(sym_float);
-      if (lookahead == '.') ADVANCE(192);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(240);
+      ACCEPT_TOKEN(anon_sym_LineHeight);
       END_STATE();
     case 241:
-      ACCEPT_TOKEN(sym_float);
-      if (lookahead == 'm') ADVANCE(250);
-      if (lookahead == 's') ADVANCE(247);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(241);
+      ACCEPT_TOKEN(anon_sym_Padding);
       END_STATE();
     case 242:
-      ACCEPT_TOKEN(sym_float);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(242);
+      ACCEPT_TOKEN(anon_sym_Theme);
       END_STATE();
     case 243:
-      ACCEPT_TOKEN(sym_integer);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(243);
+      ACCEPT_TOKEN(anon_sym_LoopOffset);
       END_STATE();
     case 244:
-      ACCEPT_TOKEN(sym_json);
-      if (lookahead == '}') ADVANCE(244);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(188);
+      ACCEPT_TOKEN(anon_sym_PERCENT);
       END_STATE();
     case 245:
+      ACCEPT_TOKEN(anon_sym_Width);
+      END_STATE();
+    case 246:
+      ACCEPT_TOKEN(anon_sym_BorderRadius);
+      END_STATE();
+    case 247:
+      ACCEPT_TOKEN(anon_sym_Margin);
+      if (lookahead == 'F') ADVANCE(113);
+      END_STATE();
+    case 248:
+      ACCEPT_TOKEN(anon_sym_MarginFill);
+      END_STATE();
+    case 249:
+      ACCEPT_TOKEN(anon_sym_WindowBar);
+      if (lookahead == 'S') ADVANCE(112);
+      END_STATE();
+    case 250:
+      ACCEPT_TOKEN(anon_sym_WindowBarSize);
+      END_STATE();
+    case 251:
+      ACCEPT_TOKEN(anon_sym_CursorBlink);
+      END_STATE();
+    case 252:
+      ACCEPT_TOKEN(aux_sym_string_token1);
+      END_STATE();
+    case 253:
+      ACCEPT_TOKEN(aux_sym_string_token2);
+      END_STATE();
+    case 254:
+      ACCEPT_TOKEN(aux_sym_string_token3);
+      END_STATE();
+    case 255:
+      ACCEPT_TOKEN(sym_comment);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(255);
+      END_STATE();
+    case 256:
+      ACCEPT_TOKEN(sym_float);
+      if (lookahead == '.') ADVANCE(206);
+      if (lookahead == 'm') ADVANCE(267);
+      if (lookahead == 's') ADVANCE(264);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(256);
+      END_STATE();
+    case 257:
+      ACCEPT_TOKEN(sym_float);
+      if (lookahead == '.') ADVANCE(207);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(257);
+      END_STATE();
+    case 258:
+      ACCEPT_TOKEN(sym_float);
+      if (lookahead == 'm') ADVANCE(267);
+      if (lookahead == 's') ADVANCE(264);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(258);
+      END_STATE();
+    case 259:
+      ACCEPT_TOKEN(sym_float);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(259);
+      END_STATE();
+    case 260:
+      ACCEPT_TOKEN(sym_integer);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(260);
+      END_STATE();
+    case 261:
+      ACCEPT_TOKEN(sym_json);
+      if (lookahead == '}') ADVANCE(261);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(204);
+      END_STATE();
+    case 262:
       ACCEPT_TOKEN(sym_path);
       if (lookahead == '%' ||
           ('-' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(245);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(262);
       END_STATE();
-    case 246:
+    case 263:
       ACCEPT_TOKEN(anon_sym_AT);
       END_STATE();
-    case 247:
+    case 264:
       ACCEPT_TOKEN(sym_time);
       END_STATE();
-    case 248:
+    case 265:
       ACCEPT_TOKEN(sym_time);
-      if (lookahead == '.') ADVANCE(191);
-      if (lookahead == 'm') ADVANCE(250);
-      if (lookahead == 's') ADVANCE(247);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(248);
+      if (lookahead == '.') ADVANCE(208);
+      if (lookahead == 'm') ADVANCE(267);
+      if (lookahead == 's') ADVANCE(264);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(265);
       END_STATE();
-    case 249:
+    case 266:
       ACCEPT_TOKEN(sym_time);
-      if (lookahead == 'm') ADVANCE(250);
-      if (lookahead == 's') ADVANCE(247);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(249);
+      if (lookahead == 'm') ADVANCE(267);
+      if (lookahead == 's') ADVANCE(264);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(266);
       END_STATE();
-    case 250:
+    case 267:
       ACCEPT_TOKEN(sym_time);
-      if (lookahead == 's') ADVANCE(247);
+      if (lookahead == 's') ADVANCE(264);
+      END_STATE();
+    case 268:
+      ACCEPT_TOKEN(sym_boolean);
       END_STATE();
     default:
       return false;
@@ -1521,31 +1593,31 @@ static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [4] = {.lex_state = 0},
   [5] = {.lex_state = 0},
   [6] = {.lex_state = 0},
-  [7] = {.lex_state = 195},
+  [7] = {.lex_state = 211},
   [8] = {.lex_state = 0},
-  [9] = {.lex_state = 195},
-  [10] = {.lex_state = 195},
-  [11] = {.lex_state = 195},
-  [12] = {.lex_state = 195},
-  [13] = {.lex_state = 195},
-  [14] = {.lex_state = 195},
-  [15] = {.lex_state = 195},
-  [16] = {.lex_state = 195},
-  [17] = {.lex_state = 195},
-  [18] = {.lex_state = 195},
-  [19] = {.lex_state = 195},
-  [20] = {.lex_state = 195},
-  [21] = {.lex_state = 195},
-  [22] = {.lex_state = 195},
-  [23] = {.lex_state = 195},
-  [24] = {.lex_state = 195},
-  [25] = {.lex_state = 195},
-  [26] = {.lex_state = 195},
-  [27] = {.lex_state = 195},
-  [28] = {.lex_state = 195},
-  [29] = {.lex_state = 195},
-  [30] = {.lex_state = 0},
-  [31] = {.lex_state = 195},
+  [9] = {.lex_state = 211},
+  [10] = {.lex_state = 211},
+  [11] = {.lex_state = 211},
+  [12] = {.lex_state = 211},
+  [13] = {.lex_state = 211},
+  [14] = {.lex_state = 211},
+  [15] = {.lex_state = 211},
+  [16] = {.lex_state = 211},
+  [17] = {.lex_state = 211},
+  [18] = {.lex_state = 211},
+  [19] = {.lex_state = 211},
+  [20] = {.lex_state = 211},
+  [21] = {.lex_state = 211},
+  [22] = {.lex_state = 0},
+  [23] = {.lex_state = 211},
+  [24] = {.lex_state = 211},
+  [25] = {.lex_state = 211},
+  [26] = {.lex_state = 211},
+  [27] = {.lex_state = 211},
+  [28] = {.lex_state = 211},
+  [29] = {.lex_state = 211},
+  [30] = {.lex_state = 211},
+  [31] = {.lex_state = 211},
   [32] = {.lex_state = 0},
   [33] = {.lex_state = 0},
   [34] = {.lex_state = 0},
@@ -1581,14 +1653,15 @@ static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [64] = {.lex_state = 0},
   [65] = {.lex_state = 0},
   [66] = {.lex_state = 0},
-  [67] = {.lex_state = 189},
+  [67] = {.lex_state = 205},
   [68] = {.lex_state = 5},
-  [69] = {.lex_state = 0},
+  [69] = {.lex_state = 211},
   [70] = {.lex_state = 6},
-  [71] = {.lex_state = 195},
-  [72] = {.lex_state = 5},
-  [73] = {.lex_state = 6},
-  [74] = {.lex_state = 5},
+  [71] = {.lex_state = 5},
+  [72] = {.lex_state = 0},
+  [73] = {.lex_state = 0},
+  [74] = {.lex_state = 6},
+  [75] = {.lex_state = 6},
 };
 
 static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
@@ -1632,6 +1705,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_MarginFill] = ACTIONS(1),
     [anon_sym_WindowBar] = ACTIONS(1),
     [anon_sym_WindowBarSize] = ACTIONS(1),
+    [anon_sym_CursorBlink] = ACTIONS(1),
     [aux_sym_string_token1] = ACTIONS(1),
     [aux_sym_string_token2] = ACTIONS(1),
     [aux_sym_string_token3] = ACTIONS(1),
@@ -1641,28 +1715,29 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym_json] = ACTIONS(1),
     [anon_sym_AT] = ACTIONS(1),
     [sym_time] = ACTIONS(1),
+    [sym_boolean] = ACTIONS(1),
   },
   [1] = {
-    [sym_program] = STATE(69),
-    [sym_command] = STATE(2),
-    [sym_hide] = STATE(35),
-    [sym_show] = STATE(35),
-    [sym_output] = STATE(35),
-    [sym_set] = STATE(35),
-    [sym_sleep] = STATE(35),
-    [sym_type] = STATE(35),
-    [sym_backspace] = STATE(35),
-    [sym_down] = STATE(35),
-    [sym_enter] = STATE(35),
-    [sym_escape] = STATE(35),
-    [sym_left] = STATE(35),
-    [sym_right] = STATE(35),
-    [sym_space] = STATE(35),
-    [sym_tab] = STATE(35),
-    [sym_up] = STATE(35),
-    [sym_pageup] = STATE(35),
-    [sym_pagedown] = STATE(35),
-    [aux_sym_program_repeat1] = STATE(2),
+    [sym_program] = STATE(73),
+    [sym_command] = STATE(3),
+    [sym_hide] = STATE(36),
+    [sym_show] = STATE(36),
+    [sym_output] = STATE(36),
+    [sym_set] = STATE(36),
+    [sym_sleep] = STATE(36),
+    [sym_type] = STATE(36),
+    [sym_backspace] = STATE(36),
+    [sym_down] = STATE(36),
+    [sym_enter] = STATE(36),
+    [sym_escape] = STATE(36),
+    [sym_left] = STATE(36),
+    [sym_right] = STATE(36),
+    [sym_space] = STATE(36),
+    [sym_tab] = STATE(36),
+    [sym_up] = STATE(36),
+    [sym_pageup] = STATE(36),
+    [sym_pagedown] = STATE(36),
+    [aux_sym_program_repeat1] = STATE(3),
     [ts_builtin_sym_end] = ACTIONS(3),
     [sym_control] = ACTIONS(5),
     [sym_alt] = ACTIONS(5),
@@ -1686,26 +1761,68 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym_comment] = ACTIONS(41),
   },
   [2] = {
-    [sym_command] = STATE(3),
-    [sym_hide] = STATE(35),
-    [sym_show] = STATE(35),
-    [sym_output] = STATE(35),
-    [sym_set] = STATE(35),
-    [sym_sleep] = STATE(35),
-    [sym_type] = STATE(35),
-    [sym_backspace] = STATE(35),
-    [sym_down] = STATE(35),
-    [sym_enter] = STATE(35),
-    [sym_escape] = STATE(35),
-    [sym_left] = STATE(35),
-    [sym_right] = STATE(35),
-    [sym_space] = STATE(35),
-    [sym_tab] = STATE(35),
-    [sym_up] = STATE(35),
-    [sym_pageup] = STATE(35),
-    [sym_pagedown] = STATE(35),
-    [aux_sym_program_repeat1] = STATE(3),
+    [sym_command] = STATE(2),
+    [sym_hide] = STATE(36),
+    [sym_show] = STATE(36),
+    [sym_output] = STATE(36),
+    [sym_set] = STATE(36),
+    [sym_sleep] = STATE(36),
+    [sym_type] = STATE(36),
+    [sym_backspace] = STATE(36),
+    [sym_down] = STATE(36),
+    [sym_enter] = STATE(36),
+    [sym_escape] = STATE(36),
+    [sym_left] = STATE(36),
+    [sym_right] = STATE(36),
+    [sym_space] = STATE(36),
+    [sym_tab] = STATE(36),
+    [sym_up] = STATE(36),
+    [sym_pageup] = STATE(36),
+    [sym_pagedown] = STATE(36),
+    [aux_sym_program_repeat1] = STATE(2),
     [ts_builtin_sym_end] = ACTIONS(43),
+    [sym_control] = ACTIONS(45),
+    [sym_alt] = ACTIONS(45),
+    [anon_sym_Hide] = ACTIONS(48),
+    [anon_sym_Show] = ACTIONS(51),
+    [anon_sym_Output] = ACTIONS(54),
+    [anon_sym_Set] = ACTIONS(57),
+    [anon_sym_Sleep] = ACTIONS(60),
+    [anon_sym_Type] = ACTIONS(63),
+    [anon_sym_Backspace] = ACTIONS(66),
+    [anon_sym_Down] = ACTIONS(69),
+    [anon_sym_Enter] = ACTIONS(72),
+    [anon_sym_Escape] = ACTIONS(75),
+    [anon_sym_Left] = ACTIONS(78),
+    [anon_sym_Right] = ACTIONS(81),
+    [anon_sym_Space] = ACTIONS(84),
+    [anon_sym_Tab] = ACTIONS(87),
+    [anon_sym_Up] = ACTIONS(90),
+    [anon_sym_PageUp] = ACTIONS(93),
+    [anon_sym_PageDown] = ACTIONS(96),
+    [sym_comment] = ACTIONS(99),
+  },
+  [3] = {
+    [sym_command] = STATE(2),
+    [sym_hide] = STATE(36),
+    [sym_show] = STATE(36),
+    [sym_output] = STATE(36),
+    [sym_set] = STATE(36),
+    [sym_sleep] = STATE(36),
+    [sym_type] = STATE(36),
+    [sym_backspace] = STATE(36),
+    [sym_down] = STATE(36),
+    [sym_enter] = STATE(36),
+    [sym_escape] = STATE(36),
+    [sym_left] = STATE(36),
+    [sym_right] = STATE(36),
+    [sym_space] = STATE(36),
+    [sym_tab] = STATE(36),
+    [sym_up] = STATE(36),
+    [sym_pageup] = STATE(36),
+    [sym_pagedown] = STATE(36),
+    [aux_sym_program_repeat1] = STATE(2),
+    [ts_builtin_sym_end] = ACTIONS(102),
     [sym_control] = ACTIONS(5),
     [sym_alt] = ACTIONS(5),
     [anon_sym_Hide] = ACTIONS(7),
@@ -1725,49 +1842,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_Up] = ACTIONS(35),
     [anon_sym_PageUp] = ACTIONS(37),
     [anon_sym_PageDown] = ACTIONS(39),
-    [sym_comment] = ACTIONS(45),
-  },
-  [3] = {
-    [sym_command] = STATE(3),
-    [sym_hide] = STATE(35),
-    [sym_show] = STATE(35),
-    [sym_output] = STATE(35),
-    [sym_set] = STATE(35),
-    [sym_sleep] = STATE(35),
-    [sym_type] = STATE(35),
-    [sym_backspace] = STATE(35),
-    [sym_down] = STATE(35),
-    [sym_enter] = STATE(35),
-    [sym_escape] = STATE(35),
-    [sym_left] = STATE(35),
-    [sym_right] = STATE(35),
-    [sym_space] = STATE(35),
-    [sym_tab] = STATE(35),
-    [sym_up] = STATE(35),
-    [sym_pageup] = STATE(35),
-    [sym_pagedown] = STATE(35),
-    [aux_sym_program_repeat1] = STATE(3),
-    [ts_builtin_sym_end] = ACTIONS(47),
-    [sym_control] = ACTIONS(49),
-    [sym_alt] = ACTIONS(49),
-    [anon_sym_Hide] = ACTIONS(52),
-    [anon_sym_Show] = ACTIONS(55),
-    [anon_sym_Output] = ACTIONS(58),
-    [anon_sym_Set] = ACTIONS(61),
-    [anon_sym_Sleep] = ACTIONS(64),
-    [anon_sym_Type] = ACTIONS(67),
-    [anon_sym_Backspace] = ACTIONS(70),
-    [anon_sym_Down] = ACTIONS(73),
-    [anon_sym_Enter] = ACTIONS(76),
-    [anon_sym_Escape] = ACTIONS(79),
-    [anon_sym_Left] = ACTIONS(82),
-    [anon_sym_Right] = ACTIONS(85),
-    [anon_sym_Space] = ACTIONS(88),
-    [anon_sym_Tab] = ACTIONS(91),
-    [anon_sym_Up] = ACTIONS(94),
-    [anon_sym_PageUp] = ACTIONS(97),
-    [anon_sym_PageDown] = ACTIONS(100),
-    [sym_comment] = ACTIONS(103),
+    [sym_comment] = ACTIONS(104),
   },
 };
 
@@ -1920,7 +1995,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_integer,
     ACTIONS(125), 1,
       anon_sym_AT,
-    STATE(29), 1,
+    STATE(21), 1,
       sym_speed,
     ACTIONS(121), 21,
       ts_builtin_sym_end,
@@ -1949,7 +2024,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AT,
     ACTIONS(129), 1,
       sym_integer,
-    STATE(28), 1,
+    STATE(20), 1,
       sym_speed,
     ACTIONS(127), 21,
       ts_builtin_sym_end,
@@ -1978,7 +2053,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AT,
     ACTIONS(133), 1,
       sym_integer,
-    STATE(27), 1,
+    STATE(31), 1,
       sym_speed,
     ACTIONS(131), 21,
       ts_builtin_sym_end,
@@ -2007,7 +2082,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AT,
     ACTIONS(137), 1,
       sym_integer,
-    STATE(26), 1,
+    STATE(30), 1,
       sym_speed,
     ACTIONS(135), 21,
       ts_builtin_sym_end,
@@ -2036,7 +2111,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AT,
     ACTIONS(141), 1,
       sym_integer,
-    STATE(25), 1,
+    STATE(29), 1,
       sym_speed,
     ACTIONS(139), 21,
       ts_builtin_sym_end,
@@ -2065,7 +2140,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AT,
     ACTIONS(145), 1,
       sym_integer,
-    STATE(24), 1,
+    STATE(28), 1,
       sym_speed,
     ACTIONS(143), 21,
       ts_builtin_sym_end,
@@ -2094,7 +2169,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AT,
     ACTIONS(149), 1,
       sym_integer,
-    STATE(23), 1,
+    STATE(27), 1,
       sym_speed,
     ACTIONS(147), 21,
       ts_builtin_sym_end,
@@ -2123,7 +2198,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AT,
     ACTIONS(153), 1,
       sym_integer,
-    STATE(22), 1,
+    STATE(26), 1,
       sym_speed,
     ACTIONS(151), 21,
       ts_builtin_sym_end,
@@ -2152,7 +2227,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AT,
     ACTIONS(157), 1,
       sym_integer,
-    STATE(21), 1,
+    STATE(25), 1,
       sym_speed,
     ACTIONS(155), 21,
       ts_builtin_sym_end,
@@ -2181,7 +2256,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AT,
     ACTIONS(161), 1,
       sym_integer,
-    STATE(20), 1,
+    STATE(24), 1,
       sym_speed,
     ACTIONS(159), 21,
       ts_builtin_sym_end,
@@ -2210,7 +2285,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AT,
     ACTIONS(165), 1,
       sym_integer,
-    STATE(31), 1,
+    STATE(23), 1,
       sym_speed,
     ACTIONS(163), 21,
       ts_builtin_sym_end,
@@ -2286,7 +2361,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_comment,
   [571] = 2,
     ACTIONS(177), 1,
-      sym_integer,
+      anon_sym_PERCENT,
     ACTIONS(175), 21,
       ts_builtin_sym_end,
       sym_control,
@@ -2486,7 +2561,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_comment,
   [787] = 2,
     ACTIONS(209), 1,
-      anon_sym_PERCENT,
+      sym_integer,
     ACTIONS(207), 21,
       ts_builtin_sym_end,
       sym_control,
@@ -2535,397 +2610,6 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PageDown,
       sym_comment,
   [841] = 1,
-    ACTIONS(203), 21,
-      ts_builtin_sym_end,
-      sym_control,
-      sym_alt,
-      anon_sym_Hide,
-      anon_sym_Show,
-      anon_sym_Output,
-      anon_sym_Set,
-      anon_sym_Sleep,
-      anon_sym_Type,
-      anon_sym_Backspace,
-      anon_sym_Down,
-      anon_sym_Enter,
-      anon_sym_Escape,
-      anon_sym_Left,
-      anon_sym_Right,
-      anon_sym_Space,
-      anon_sym_Tab,
-      anon_sym_Up,
-      anon_sym_PageUp,
-      anon_sym_PageDown,
-      sym_comment,
-  [865] = 1,
-    ACTIONS(167), 21,
-      ts_builtin_sym_end,
-      sym_control,
-      sym_alt,
-      anon_sym_Hide,
-      anon_sym_Show,
-      anon_sym_Output,
-      anon_sym_Set,
-      anon_sym_Sleep,
-      anon_sym_Type,
-      anon_sym_Backspace,
-      anon_sym_Down,
-      anon_sym_Enter,
-      anon_sym_Escape,
-      anon_sym_Left,
-      anon_sym_Right,
-      anon_sym_Space,
-      anon_sym_Tab,
-      anon_sym_Up,
-      anon_sym_PageUp,
-      anon_sym_PageDown,
-      sym_comment,
-  [889] = 1,
-    ACTIONS(215), 21,
-      ts_builtin_sym_end,
-      sym_control,
-      sym_alt,
-      anon_sym_Hide,
-      anon_sym_Show,
-      anon_sym_Output,
-      anon_sym_Set,
-      anon_sym_Sleep,
-      anon_sym_Type,
-      anon_sym_Backspace,
-      anon_sym_Down,
-      anon_sym_Enter,
-      anon_sym_Escape,
-      anon_sym_Left,
-      anon_sym_Right,
-      anon_sym_Space,
-      anon_sym_Tab,
-      anon_sym_Up,
-      anon_sym_PageUp,
-      anon_sym_PageDown,
-      sym_comment,
-  [913] = 1,
-    ACTIONS(217), 21,
-      ts_builtin_sym_end,
-      sym_control,
-      sym_alt,
-      anon_sym_Hide,
-      anon_sym_Show,
-      anon_sym_Output,
-      anon_sym_Set,
-      anon_sym_Sleep,
-      anon_sym_Type,
-      anon_sym_Backspace,
-      anon_sym_Down,
-      anon_sym_Enter,
-      anon_sym_Escape,
-      anon_sym_Left,
-      anon_sym_Right,
-      anon_sym_Space,
-      anon_sym_Tab,
-      anon_sym_Up,
-      anon_sym_PageUp,
-      anon_sym_PageDown,
-      sym_comment,
-  [937] = 1,
-    ACTIONS(219), 21,
-      ts_builtin_sym_end,
-      sym_control,
-      sym_alt,
-      anon_sym_Hide,
-      anon_sym_Show,
-      anon_sym_Output,
-      anon_sym_Set,
-      anon_sym_Sleep,
-      anon_sym_Type,
-      anon_sym_Backspace,
-      anon_sym_Down,
-      anon_sym_Enter,
-      anon_sym_Escape,
-      anon_sym_Left,
-      anon_sym_Right,
-      anon_sym_Space,
-      anon_sym_Tab,
-      anon_sym_Up,
-      anon_sym_PageUp,
-      anon_sym_PageDown,
-      sym_comment,
-  [961] = 1,
-    ACTIONS(199), 21,
-      ts_builtin_sym_end,
-      sym_control,
-      sym_alt,
-      anon_sym_Hide,
-      anon_sym_Show,
-      anon_sym_Output,
-      anon_sym_Set,
-      anon_sym_Sleep,
-      anon_sym_Type,
-      anon_sym_Backspace,
-      anon_sym_Down,
-      anon_sym_Enter,
-      anon_sym_Escape,
-      anon_sym_Left,
-      anon_sym_Right,
-      anon_sym_Space,
-      anon_sym_Tab,
-      anon_sym_Up,
-      anon_sym_PageUp,
-      anon_sym_PageDown,
-      sym_comment,
-  [985] = 1,
-    ACTIONS(221), 21,
-      ts_builtin_sym_end,
-      sym_control,
-      sym_alt,
-      anon_sym_Hide,
-      anon_sym_Show,
-      anon_sym_Output,
-      anon_sym_Set,
-      anon_sym_Sleep,
-      anon_sym_Type,
-      anon_sym_Backspace,
-      anon_sym_Down,
-      anon_sym_Enter,
-      anon_sym_Escape,
-      anon_sym_Left,
-      anon_sym_Right,
-      anon_sym_Space,
-      anon_sym_Tab,
-      anon_sym_Up,
-      anon_sym_PageUp,
-      anon_sym_PageDown,
-      sym_comment,
-  [1009] = 1,
-    ACTIONS(195), 21,
-      ts_builtin_sym_end,
-      sym_control,
-      sym_alt,
-      anon_sym_Hide,
-      anon_sym_Show,
-      anon_sym_Output,
-      anon_sym_Set,
-      anon_sym_Sleep,
-      anon_sym_Type,
-      anon_sym_Backspace,
-      anon_sym_Down,
-      anon_sym_Enter,
-      anon_sym_Escape,
-      anon_sym_Left,
-      anon_sym_Right,
-      anon_sym_Space,
-      anon_sym_Tab,
-      anon_sym_Up,
-      anon_sym_PageUp,
-      anon_sym_PageDown,
-      sym_comment,
-  [1033] = 1,
-    ACTIONS(223), 21,
-      ts_builtin_sym_end,
-      sym_control,
-      sym_alt,
-      anon_sym_Hide,
-      anon_sym_Show,
-      anon_sym_Output,
-      anon_sym_Set,
-      anon_sym_Sleep,
-      anon_sym_Type,
-      anon_sym_Backspace,
-      anon_sym_Down,
-      anon_sym_Enter,
-      anon_sym_Escape,
-      anon_sym_Left,
-      anon_sym_Right,
-      anon_sym_Space,
-      anon_sym_Tab,
-      anon_sym_Up,
-      anon_sym_PageUp,
-      anon_sym_PageDown,
-      sym_comment,
-  [1057] = 1,
-    ACTIONS(191), 21,
-      ts_builtin_sym_end,
-      sym_control,
-      sym_alt,
-      anon_sym_Hide,
-      anon_sym_Show,
-      anon_sym_Output,
-      anon_sym_Set,
-      anon_sym_Sleep,
-      anon_sym_Type,
-      anon_sym_Backspace,
-      anon_sym_Down,
-      anon_sym_Enter,
-      anon_sym_Escape,
-      anon_sym_Left,
-      anon_sym_Right,
-      anon_sym_Space,
-      anon_sym_Tab,
-      anon_sym_Up,
-      anon_sym_PageUp,
-      anon_sym_PageDown,
-      sym_comment,
-  [1081] = 1,
-    ACTIONS(225), 21,
-      ts_builtin_sym_end,
-      sym_control,
-      sym_alt,
-      anon_sym_Hide,
-      anon_sym_Show,
-      anon_sym_Output,
-      anon_sym_Set,
-      anon_sym_Sleep,
-      anon_sym_Type,
-      anon_sym_Backspace,
-      anon_sym_Down,
-      anon_sym_Enter,
-      anon_sym_Escape,
-      anon_sym_Left,
-      anon_sym_Right,
-      anon_sym_Space,
-      anon_sym_Tab,
-      anon_sym_Up,
-      anon_sym_PageUp,
-      anon_sym_PageDown,
-      sym_comment,
-  [1105] = 1,
-    ACTIONS(187), 21,
-      ts_builtin_sym_end,
-      sym_control,
-      sym_alt,
-      anon_sym_Hide,
-      anon_sym_Show,
-      anon_sym_Output,
-      anon_sym_Set,
-      anon_sym_Sleep,
-      anon_sym_Type,
-      anon_sym_Backspace,
-      anon_sym_Down,
-      anon_sym_Enter,
-      anon_sym_Escape,
-      anon_sym_Left,
-      anon_sym_Right,
-      anon_sym_Space,
-      anon_sym_Tab,
-      anon_sym_Up,
-      anon_sym_PageUp,
-      anon_sym_PageDown,
-      sym_comment,
-  [1129] = 1,
-    ACTIONS(227), 21,
-      ts_builtin_sym_end,
-      sym_control,
-      sym_alt,
-      anon_sym_Hide,
-      anon_sym_Show,
-      anon_sym_Output,
-      anon_sym_Set,
-      anon_sym_Sleep,
-      anon_sym_Type,
-      anon_sym_Backspace,
-      anon_sym_Down,
-      anon_sym_Enter,
-      anon_sym_Escape,
-      anon_sym_Left,
-      anon_sym_Right,
-      anon_sym_Space,
-      anon_sym_Tab,
-      anon_sym_Up,
-      anon_sym_PageUp,
-      anon_sym_PageDown,
-      sym_comment,
-  [1153] = 1,
-    ACTIONS(183), 21,
-      ts_builtin_sym_end,
-      sym_control,
-      sym_alt,
-      anon_sym_Hide,
-      anon_sym_Show,
-      anon_sym_Output,
-      anon_sym_Set,
-      anon_sym_Sleep,
-      anon_sym_Type,
-      anon_sym_Backspace,
-      anon_sym_Down,
-      anon_sym_Enter,
-      anon_sym_Escape,
-      anon_sym_Left,
-      anon_sym_Right,
-      anon_sym_Space,
-      anon_sym_Tab,
-      anon_sym_Up,
-      anon_sym_PageUp,
-      anon_sym_PageDown,
-      sym_comment,
-  [1177] = 1,
-    ACTIONS(229), 21,
-      ts_builtin_sym_end,
-      sym_control,
-      sym_alt,
-      anon_sym_Hide,
-      anon_sym_Show,
-      anon_sym_Output,
-      anon_sym_Set,
-      anon_sym_Sleep,
-      anon_sym_Type,
-      anon_sym_Backspace,
-      anon_sym_Down,
-      anon_sym_Enter,
-      anon_sym_Escape,
-      anon_sym_Left,
-      anon_sym_Right,
-      anon_sym_Space,
-      anon_sym_Tab,
-      anon_sym_Up,
-      anon_sym_PageUp,
-      anon_sym_PageDown,
-      sym_comment,
-  [1201] = 1,
-    ACTIONS(179), 21,
-      ts_builtin_sym_end,
-      sym_control,
-      sym_alt,
-      anon_sym_Hide,
-      anon_sym_Show,
-      anon_sym_Output,
-      anon_sym_Set,
-      anon_sym_Sleep,
-      anon_sym_Type,
-      anon_sym_Backspace,
-      anon_sym_Down,
-      anon_sym_Enter,
-      anon_sym_Escape,
-      anon_sym_Left,
-      anon_sym_Right,
-      anon_sym_Space,
-      anon_sym_Tab,
-      anon_sym_Up,
-      anon_sym_PageUp,
-      anon_sym_PageDown,
-      sym_comment,
-  [1225] = 1,
-    ACTIONS(231), 21,
-      ts_builtin_sym_end,
-      sym_control,
-      sym_alt,
-      anon_sym_Hide,
-      anon_sym_Show,
-      anon_sym_Output,
-      anon_sym_Set,
-      anon_sym_Sleep,
-      anon_sym_Type,
-      anon_sym_Backspace,
-      anon_sym_Down,
-      anon_sym_Enter,
-      anon_sym_Escape,
-      anon_sym_Left,
-      anon_sym_Right,
-      anon_sym_Space,
-      anon_sym_Tab,
-      anon_sym_Up,
-      anon_sym_PageUp,
-      anon_sym_PageDown,
-      sym_comment,
-  [1249] = 1,
     ACTIONS(175), 21,
       ts_builtin_sym_end,
       sym_control,
@@ -2948,8 +2632,8 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PageUp,
       anon_sym_PageDown,
       sym_comment,
-  [1273] = 1,
-    ACTIONS(233), 21,
+  [865] = 1,
+    ACTIONS(215), 21,
       ts_builtin_sym_end,
       sym_control,
       sym_alt,
@@ -2971,7 +2655,76 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PageUp,
       anon_sym_PageDown,
       sym_comment,
-  [1297] = 1,
+  [889] = 1,
+    ACTIONS(217), 21,
+      ts_builtin_sym_end,
+      sym_control,
+      sym_alt,
+      anon_sym_Hide,
+      anon_sym_Show,
+      anon_sym_Output,
+      anon_sym_Set,
+      anon_sym_Sleep,
+      anon_sym_Type,
+      anon_sym_Backspace,
+      anon_sym_Down,
+      anon_sym_Enter,
+      anon_sym_Escape,
+      anon_sym_Left,
+      anon_sym_Right,
+      anon_sym_Space,
+      anon_sym_Tab,
+      anon_sym_Up,
+      anon_sym_PageUp,
+      anon_sym_PageDown,
+      sym_comment,
+  [913] = 1,
+    ACTIONS(219), 21,
+      ts_builtin_sym_end,
+      sym_control,
+      sym_alt,
+      anon_sym_Hide,
+      anon_sym_Show,
+      anon_sym_Output,
+      anon_sym_Set,
+      anon_sym_Sleep,
+      anon_sym_Type,
+      anon_sym_Backspace,
+      anon_sym_Down,
+      anon_sym_Enter,
+      anon_sym_Escape,
+      anon_sym_Left,
+      anon_sym_Right,
+      anon_sym_Space,
+      anon_sym_Tab,
+      anon_sym_Up,
+      anon_sym_PageUp,
+      anon_sym_PageDown,
+      sym_comment,
+  [937] = 1,
+    ACTIONS(221), 21,
+      ts_builtin_sym_end,
+      sym_control,
+      sym_alt,
+      anon_sym_Hide,
+      anon_sym_Show,
+      anon_sym_Output,
+      anon_sym_Set,
+      anon_sym_Sleep,
+      anon_sym_Type,
+      anon_sym_Backspace,
+      anon_sym_Down,
+      anon_sym_Enter,
+      anon_sym_Escape,
+      anon_sym_Left,
+      anon_sym_Right,
+      anon_sym_Space,
+      anon_sym_Tab,
+      anon_sym_Up,
+      anon_sym_PageUp,
+      anon_sym_PageDown,
+      sym_comment,
+  [961] = 1,
     ACTIONS(171), 21,
       ts_builtin_sym_end,
       sym_control,
@@ -2994,8 +2747,330 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PageUp,
       anon_sym_PageDown,
       sym_comment,
-  [1321] = 1,
+  [985] = 1,
+    ACTIONS(167), 21,
+      ts_builtin_sym_end,
+      sym_control,
+      sym_alt,
+      anon_sym_Hide,
+      anon_sym_Show,
+      anon_sym_Output,
+      anon_sym_Set,
+      anon_sym_Sleep,
+      anon_sym_Type,
+      anon_sym_Backspace,
+      anon_sym_Down,
+      anon_sym_Enter,
+      anon_sym_Escape,
+      anon_sym_Left,
+      anon_sym_Right,
+      anon_sym_Space,
+      anon_sym_Tab,
+      anon_sym_Up,
+      anon_sym_PageUp,
+      anon_sym_PageDown,
+      sym_comment,
+  [1009] = 1,
+    ACTIONS(223), 21,
+      ts_builtin_sym_end,
+      sym_control,
+      sym_alt,
+      anon_sym_Hide,
+      anon_sym_Show,
+      anon_sym_Output,
+      anon_sym_Set,
+      anon_sym_Sleep,
+      anon_sym_Type,
+      anon_sym_Backspace,
+      anon_sym_Down,
+      anon_sym_Enter,
+      anon_sym_Escape,
+      anon_sym_Left,
+      anon_sym_Right,
+      anon_sym_Space,
+      anon_sym_Tab,
+      anon_sym_Up,
+      anon_sym_PageUp,
+      anon_sym_PageDown,
+      sym_comment,
+  [1033] = 1,
+    ACTIONS(211), 21,
+      ts_builtin_sym_end,
+      sym_control,
+      sym_alt,
+      anon_sym_Hide,
+      anon_sym_Show,
+      anon_sym_Output,
+      anon_sym_Set,
+      anon_sym_Sleep,
+      anon_sym_Type,
+      anon_sym_Backspace,
+      anon_sym_Down,
+      anon_sym_Enter,
+      anon_sym_Escape,
+      anon_sym_Left,
+      anon_sym_Right,
+      anon_sym_Space,
+      anon_sym_Tab,
+      anon_sym_Up,
+      anon_sym_PageUp,
+      anon_sym_PageDown,
+      sym_comment,
+  [1057] = 1,
+    ACTIONS(225), 21,
+      ts_builtin_sym_end,
+      sym_control,
+      sym_alt,
+      anon_sym_Hide,
+      anon_sym_Show,
+      anon_sym_Output,
+      anon_sym_Set,
+      anon_sym_Sleep,
+      anon_sym_Type,
+      anon_sym_Backspace,
+      anon_sym_Down,
+      anon_sym_Enter,
+      anon_sym_Escape,
+      anon_sym_Left,
+      anon_sym_Right,
+      anon_sym_Space,
+      anon_sym_Tab,
+      anon_sym_Up,
+      anon_sym_PageUp,
+      anon_sym_PageDown,
+      sym_comment,
+  [1081] = 1,
+    ACTIONS(207), 21,
+      ts_builtin_sym_end,
+      sym_control,
+      sym_alt,
+      anon_sym_Hide,
+      anon_sym_Show,
+      anon_sym_Output,
+      anon_sym_Set,
+      anon_sym_Sleep,
+      anon_sym_Type,
+      anon_sym_Backspace,
+      anon_sym_Down,
+      anon_sym_Enter,
+      anon_sym_Escape,
+      anon_sym_Left,
+      anon_sym_Right,
+      anon_sym_Space,
+      anon_sym_Tab,
+      anon_sym_Up,
+      anon_sym_PageUp,
+      anon_sym_PageDown,
+      sym_comment,
+  [1105] = 1,
+    ACTIONS(227), 21,
+      ts_builtin_sym_end,
+      sym_control,
+      sym_alt,
+      anon_sym_Hide,
+      anon_sym_Show,
+      anon_sym_Output,
+      anon_sym_Set,
+      anon_sym_Sleep,
+      anon_sym_Type,
+      anon_sym_Backspace,
+      anon_sym_Down,
+      anon_sym_Enter,
+      anon_sym_Escape,
+      anon_sym_Left,
+      anon_sym_Right,
+      anon_sym_Space,
+      anon_sym_Tab,
+      anon_sym_Up,
+      anon_sym_PageUp,
+      anon_sym_PageDown,
+      sym_comment,
+  [1129] = 1,
+    ACTIONS(203), 21,
+      ts_builtin_sym_end,
+      sym_control,
+      sym_alt,
+      anon_sym_Hide,
+      anon_sym_Show,
+      anon_sym_Output,
+      anon_sym_Set,
+      anon_sym_Sleep,
+      anon_sym_Type,
+      anon_sym_Backspace,
+      anon_sym_Down,
+      anon_sym_Enter,
+      anon_sym_Escape,
+      anon_sym_Left,
+      anon_sym_Right,
+      anon_sym_Space,
+      anon_sym_Tab,
+      anon_sym_Up,
+      anon_sym_PageUp,
+      anon_sym_PageDown,
+      sym_comment,
+  [1153] = 1,
+    ACTIONS(229), 21,
+      ts_builtin_sym_end,
+      sym_control,
+      sym_alt,
+      anon_sym_Hide,
+      anon_sym_Show,
+      anon_sym_Output,
+      anon_sym_Set,
+      anon_sym_Sleep,
+      anon_sym_Type,
+      anon_sym_Backspace,
+      anon_sym_Down,
+      anon_sym_Enter,
+      anon_sym_Escape,
+      anon_sym_Left,
+      anon_sym_Right,
+      anon_sym_Space,
+      anon_sym_Tab,
+      anon_sym_Up,
+      anon_sym_PageUp,
+      anon_sym_PageDown,
+      sym_comment,
+  [1177] = 1,
+    ACTIONS(199), 21,
+      ts_builtin_sym_end,
+      sym_control,
+      sym_alt,
+      anon_sym_Hide,
+      anon_sym_Show,
+      anon_sym_Output,
+      anon_sym_Set,
+      anon_sym_Sleep,
+      anon_sym_Type,
+      anon_sym_Backspace,
+      anon_sym_Down,
+      anon_sym_Enter,
+      anon_sym_Escape,
+      anon_sym_Left,
+      anon_sym_Right,
+      anon_sym_Space,
+      anon_sym_Tab,
+      anon_sym_Up,
+      anon_sym_PageUp,
+      anon_sym_PageDown,
+      sym_comment,
+  [1201] = 1,
+    ACTIONS(231), 21,
+      ts_builtin_sym_end,
+      sym_control,
+      sym_alt,
+      anon_sym_Hide,
+      anon_sym_Show,
+      anon_sym_Output,
+      anon_sym_Set,
+      anon_sym_Sleep,
+      anon_sym_Type,
+      anon_sym_Backspace,
+      anon_sym_Down,
+      anon_sym_Enter,
+      anon_sym_Escape,
+      anon_sym_Left,
+      anon_sym_Right,
+      anon_sym_Space,
+      anon_sym_Tab,
+      anon_sym_Up,
+      anon_sym_PageUp,
+      anon_sym_PageDown,
+      sym_comment,
+  [1225] = 1,
+    ACTIONS(195), 21,
+      ts_builtin_sym_end,
+      sym_control,
+      sym_alt,
+      anon_sym_Hide,
+      anon_sym_Show,
+      anon_sym_Output,
+      anon_sym_Set,
+      anon_sym_Sleep,
+      anon_sym_Type,
+      anon_sym_Backspace,
+      anon_sym_Down,
+      anon_sym_Enter,
+      anon_sym_Escape,
+      anon_sym_Left,
+      anon_sym_Right,
+      anon_sym_Space,
+      anon_sym_Tab,
+      anon_sym_Up,
+      anon_sym_PageUp,
+      anon_sym_PageDown,
+      sym_comment,
+  [1249] = 1,
+    ACTIONS(233), 21,
+      ts_builtin_sym_end,
+      sym_control,
+      sym_alt,
+      anon_sym_Hide,
+      anon_sym_Show,
+      anon_sym_Output,
+      anon_sym_Set,
+      anon_sym_Sleep,
+      anon_sym_Type,
+      anon_sym_Backspace,
+      anon_sym_Down,
+      anon_sym_Enter,
+      anon_sym_Escape,
+      anon_sym_Left,
+      anon_sym_Right,
+      anon_sym_Space,
+      anon_sym_Tab,
+      anon_sym_Up,
+      anon_sym_PageUp,
+      anon_sym_PageDown,
+      sym_comment,
+  [1273] = 1,
+    ACTIONS(191), 21,
+      ts_builtin_sym_end,
+      sym_control,
+      sym_alt,
+      anon_sym_Hide,
+      anon_sym_Show,
+      anon_sym_Output,
+      anon_sym_Set,
+      anon_sym_Sleep,
+      anon_sym_Type,
+      anon_sym_Backspace,
+      anon_sym_Down,
+      anon_sym_Enter,
+      anon_sym_Escape,
+      anon_sym_Left,
+      anon_sym_Right,
+      anon_sym_Space,
+      anon_sym_Tab,
+      anon_sym_Up,
+      anon_sym_PageUp,
+      anon_sym_PageDown,
+      sym_comment,
+  [1297] = 1,
     ACTIONS(235), 21,
+      ts_builtin_sym_end,
+      sym_control,
+      sym_alt,
+      anon_sym_Hide,
+      anon_sym_Show,
+      anon_sym_Output,
+      anon_sym_Set,
+      anon_sym_Sleep,
+      anon_sym_Type,
+      anon_sym_Backspace,
+      anon_sym_Down,
+      anon_sym_Enter,
+      anon_sym_Escape,
+      anon_sym_Left,
+      anon_sym_Right,
+      anon_sym_Space,
+      anon_sym_Tab,
+      anon_sym_Up,
+      anon_sym_PageUp,
+      anon_sym_PageDown,
+      sym_comment,
+  [1321] = 1,
+    ACTIONS(187), 21,
       ts_builtin_sym_end,
       sym_control,
       sym_alt,
@@ -3041,7 +3116,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PageDown,
       sym_comment,
   [1369] = 1,
-    ACTIONS(239), 21,
+    ACTIONS(183), 21,
       ts_builtin_sym_end,
       sym_control,
       sym_alt,
@@ -3064,7 +3139,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PageDown,
       sym_comment,
   [1393] = 1,
-    ACTIONS(211), 21,
+    ACTIONS(239), 21,
       ts_builtin_sym_end,
       sym_control,
       sym_alt,
@@ -3087,7 +3162,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PageDown,
       sym_comment,
   [1417] = 1,
-    ACTIONS(241), 21,
+    ACTIONS(179), 21,
       ts_builtin_sym_end,
       sym_control,
       sym_alt,
@@ -3110,7 +3185,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PageDown,
       sym_comment,
   [1441] = 1,
-    ACTIONS(243), 21,
+    ACTIONS(241), 21,
       ts_builtin_sym_end,
       sym_control,
       sym_alt,
@@ -3133,7 +3208,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PageDown,
       sym_comment,
   [1465] = 1,
-    ACTIONS(207), 21,
+    ACTIONS(243), 21,
       ts_builtin_sym_end,
       sym_control,
       sym_alt,
@@ -3224,7 +3299,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PageUp,
       anon_sym_PageDown,
       sym_comment,
-  [1561] = 9,
+  [1561] = 10,
     ACTIONS(257), 1,
       anon_sym_TypingSpeed,
     ACTIONS(259), 1,
@@ -3235,7 +3310,9 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_Margin,
     ACTIONS(265), 1,
       anon_sym_WindowBar,
-    STATE(38), 1,
+    ACTIONS(267), 1,
+      anon_sym_CursorBlink,
+    STATE(43), 1,
       sym_setting,
     ACTIONS(251), 3,
       anon_sym_Shell,
@@ -3253,10 +3330,10 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_Width,
       anon_sym_BorderRadius,
       anon_sym_WindowBarSize,
-  [1599] = 4,
+  [1602] = 4,
     ACTIONS(125), 1,
       anon_sym_AT,
-    STATE(64), 1,
+    STATE(65), 1,
       sym_speed,
     STATE(6), 2,
       sym_string,
@@ -3265,7 +3342,16 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_string_token1,
       aux_sym_string_token2,
       aux_sym_string_token3,
-  [1615] = 2,
+  [1618] = 3,
+    ACTIONS(269), 1,
+      sym_json,
+    STATE(32), 1,
+      sym_string,
+    ACTIONS(113), 3,
+      aux_sym_string_token1,
+      aux_sym_string_token2,
+      aux_sym_string_token3,
+  [1630] = 2,
     STATE(5), 2,
       sym_string,
       aux_sym_type_repeat1,
@@ -3273,45 +3359,39 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_string_token1,
       aux_sym_string_token2,
       aux_sym_string_token3,
-  [1625] = 3,
-    ACTIONS(267), 1,
-      sym_json,
-    STATE(58), 1,
+  [1640] = 2,
+    STATE(32), 1,
       sym_string,
     ACTIONS(113), 3,
       aux_sym_string_token1,
       aux_sym_string_token2,
       aux_sym_string_token3,
-  [1637] = 2,
-    STATE(58), 1,
-      sym_string,
-    ACTIONS(113), 3,
-      aux_sym_string_token1,
-      aux_sym_string_token2,
-      aux_sym_string_token3,
-  [1646] = 1,
-    ACTIONS(269), 1,
-      sym_path,
-  [1650] = 1,
+  [1649] = 1,
     ACTIONS(271), 1,
-      sym_time,
-  [1654] = 1,
-    ACTIONS(273), 1,
-      ts_builtin_sym_end,
-  [1658] = 1,
-    ACTIONS(267), 1,
+      sym_path,
+  [1653] = 1,
+    ACTIONS(269), 1,
       sym_float,
-  [1662] = 1,
-    ACTIONS(267), 1,
+  [1657] = 1,
+    ACTIONS(269), 1,
       sym_integer,
-  [1666] = 1,
-    ACTIONS(267), 1,
+  [1661] = 1,
+    ACTIONS(269), 1,
       sym_time,
-  [1670] = 1,
-    ACTIONS(275), 1,
+  [1665] = 1,
+    ACTIONS(273), 1,
       sym_float,
-  [1674] = 1,
+  [1669] = 1,
+    ACTIONS(269), 1,
+      sym_boolean,
+  [1673] = 1,
+    ACTIONS(275), 1,
+      ts_builtin_sym_end,
+  [1677] = 1,
     ACTIONS(277), 1,
+      sym_time,
+  [1681] = 1,
+    ACTIONS(279), 1,
       sym_time,
 };
 
@@ -3375,30 +3455,31 @@ static const uint32_t ts_small_parse_table_map[] = {
   [SMALL_STATE(60)] = 1513,
   [SMALL_STATE(61)] = 1537,
   [SMALL_STATE(62)] = 1561,
-  [SMALL_STATE(63)] = 1599,
-  [SMALL_STATE(64)] = 1615,
-  [SMALL_STATE(65)] = 1625,
-  [SMALL_STATE(66)] = 1637,
-  [SMALL_STATE(67)] = 1646,
-  [SMALL_STATE(68)] = 1650,
-  [SMALL_STATE(69)] = 1654,
-  [SMALL_STATE(70)] = 1658,
-  [SMALL_STATE(71)] = 1662,
-  [SMALL_STATE(72)] = 1666,
-  [SMALL_STATE(73)] = 1670,
-  [SMALL_STATE(74)] = 1674,
+  [SMALL_STATE(63)] = 1602,
+  [SMALL_STATE(64)] = 1618,
+  [SMALL_STATE(65)] = 1630,
+  [SMALL_STATE(66)] = 1640,
+  [SMALL_STATE(67)] = 1649,
+  [SMALL_STATE(68)] = 1653,
+  [SMALL_STATE(69)] = 1657,
+  [SMALL_STATE(70)] = 1661,
+  [SMALL_STATE(71)] = 1665,
+  [SMALL_STATE(72)] = 1669,
+  [SMALL_STATE(73)] = 1673,
+  [SMALL_STATE(74)] = 1677,
+  [SMALL_STATE(75)] = 1681,
 };
 
 static const TSParseActionEntry ts_parse_actions[] = {
   [0] = {.entry = {.count = 0, .reusable = false}},
   [1] = {.entry = {.count = 1, .reusable = false}}, RECOVER(),
   [3] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_program, 0),
-  [5] = {.entry = {.count = 1, .reusable = true}}, SHIFT(35),
-  [7] = {.entry = {.count = 1, .reusable = true}}, SHIFT(60),
+  [5] = {.entry = {.count = 1, .reusable = true}}, SHIFT(36),
+  [7] = {.entry = {.count = 1, .reusable = true}}, SHIFT(33),
   [9] = {.entry = {.count = 1, .reusable = true}}, SHIFT(61),
   [11] = {.entry = {.count = 1, .reusable = true}}, SHIFT(67),
   [13] = {.entry = {.count = 1, .reusable = true}}, SHIFT(62),
-  [15] = {.entry = {.count = 1, .reusable = true}}, SHIFT(68),
+  [15] = {.entry = {.count = 1, .reusable = true}}, SHIFT(74),
   [17] = {.entry = {.count = 1, .reusable = true}}, SHIFT(63),
   [19] = {.entry = {.count = 1, .reusable = true}}, SHIFT(9),
   [21] = {.entry = {.count = 1, .reusable = true}}, SHIFT(10),
@@ -3411,29 +3492,29 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [35] = {.entry = {.count = 1, .reusable = true}}, SHIFT(17),
   [37] = {.entry = {.count = 1, .reusable = true}}, SHIFT(18),
   [39] = {.entry = {.count = 1, .reusable = true}}, SHIFT(19),
-  [41] = {.entry = {.count = 1, .reusable = true}}, SHIFT(2),
-  [43] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_program, 1),
-  [45] = {.entry = {.count = 1, .reusable = true}}, SHIFT(3),
-  [47] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2),
-  [49] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(35),
-  [52] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(60),
-  [55] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(61),
-  [58] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(67),
-  [61] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(62),
-  [64] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(68),
-  [67] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(63),
-  [70] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(9),
-  [73] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(10),
-  [76] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(11),
-  [79] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(12),
-  [82] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(13),
-  [85] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(14),
-  [88] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(15),
-  [91] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(16),
-  [94] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(17),
-  [97] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(18),
-  [100] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(19),
-  [103] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(3),
+  [41] = {.entry = {.count = 1, .reusable = true}}, SHIFT(3),
+  [43] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2),
+  [45] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(36),
+  [48] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(33),
+  [51] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(61),
+  [54] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(67),
+  [57] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(62),
+  [60] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(74),
+  [63] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(63),
+  [66] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(9),
+  [69] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(10),
+  [72] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(11),
+  [75] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(12),
+  [78] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(13),
+  [81] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(14),
+  [84] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(15),
+  [87] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(16),
+  [90] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(17),
+  [93] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(18),
+  [96] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(19),
+  [99] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(2),
+  [102] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_program, 1),
+  [104] = {.entry = {.count = 1, .reusable = true}}, SHIFT(2),
   [106] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_type_repeat1, 2),
   [108] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_type_repeat1, 2), SHIFT_REPEAT(8),
   [111] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_type, 3),
@@ -3442,84 +3523,85 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [117] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_speed, 2),
   [119] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_string, 1),
   [121] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_backspace, 1),
-  [123] = {.entry = {.count = 1, .reusable = true}}, SHIFT(32),
-  [125] = {.entry = {.count = 1, .reusable = true}}, SHIFT(74),
+  [123] = {.entry = {.count = 1, .reusable = true}}, SHIFT(37),
+  [125] = {.entry = {.count = 1, .reusable = true}}, SHIFT(75),
   [127] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_down, 1),
-  [129] = {.entry = {.count = 1, .reusable = true}}, SHIFT(37),
+  [129] = {.entry = {.count = 1, .reusable = true}}, SHIFT(38),
   [131] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_enter, 1),
-  [133] = {.entry = {.count = 1, .reusable = true}}, SHIFT(39),
+  [133] = {.entry = {.count = 1, .reusable = true}}, SHIFT(40),
   [135] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_escape, 1),
-  [137] = {.entry = {.count = 1, .reusable = true}}, SHIFT(41),
+  [137] = {.entry = {.count = 1, .reusable = true}}, SHIFT(42),
   [139] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_left, 1),
-  [141] = {.entry = {.count = 1, .reusable = true}}, SHIFT(43),
+  [141] = {.entry = {.count = 1, .reusable = true}}, SHIFT(44),
   [143] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_right, 1),
-  [145] = {.entry = {.count = 1, .reusable = true}}, SHIFT(45),
+  [145] = {.entry = {.count = 1, .reusable = true}}, SHIFT(46),
   [147] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_space, 1),
-  [149] = {.entry = {.count = 1, .reusable = true}}, SHIFT(47),
+  [149] = {.entry = {.count = 1, .reusable = true}}, SHIFT(48),
   [151] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tab, 1),
-  [153] = {.entry = {.count = 1, .reusable = true}}, SHIFT(49),
+  [153] = {.entry = {.count = 1, .reusable = true}}, SHIFT(50),
   [155] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_up, 1),
-  [157] = {.entry = {.count = 1, .reusable = true}}, SHIFT(51),
+  [157] = {.entry = {.count = 1, .reusable = true}}, SHIFT(52),
   [159] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_pageup, 1),
-  [161] = {.entry = {.count = 1, .reusable = true}}, SHIFT(33),
+  [161] = {.entry = {.count = 1, .reusable = true}}, SHIFT(54),
   [163] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_pagedown, 1),
-  [165] = {.entry = {.count = 1, .reusable = true}}, SHIFT(55),
-  [167] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_pageup, 2),
-  [169] = {.entry = {.count = 1, .reusable = true}}, SHIFT(42),
-  [171] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_up, 2),
-  [173] = {.entry = {.count = 1, .reusable = true}}, SHIFT(44),
-  [175] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tab, 2),
-  [177] = {.entry = {.count = 1, .reusable = true}}, SHIFT(46),
-  [179] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_space, 2),
-  [181] = {.entry = {.count = 1, .reusable = true}}, SHIFT(48),
-  [183] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_right, 2),
-  [185] = {.entry = {.count = 1, .reusable = true}}, SHIFT(50),
-  [187] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_left, 2),
-  [189] = {.entry = {.count = 1, .reusable = true}}, SHIFT(53),
-  [191] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_escape, 2),
-  [193] = {.entry = {.count = 1, .reusable = true}}, SHIFT(54),
-  [195] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_enter, 2),
-  [197] = {.entry = {.count = 1, .reusable = true}}, SHIFT(56),
-  [199] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_down, 2),
-  [201] = {.entry = {.count = 1, .reusable = true}}, SHIFT(57),
-  [203] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_backspace, 2),
-  [205] = {.entry = {.count = 1, .reusable = true}}, SHIFT(59),
-  [207] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_setting, 2),
-  [209] = {.entry = {.count = 1, .reusable = true}}, SHIFT(34),
-  [211] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_pagedown, 2),
-  [213] = {.entry = {.count = 1, .reusable = true}}, SHIFT(40),
-  [215] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_setting, 3),
-  [217] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_command, 1),
-  [219] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_sleep, 2),
-  [221] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_set, 2),
-  [223] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_pagedown, 3),
-  [225] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_pageup, 3),
-  [227] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_up, 3),
+  [165] = {.entry = {.count = 1, .reusable = true}}, SHIFT(56),
+  [167] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_down, 2),
+  [169] = {.entry = {.count = 1, .reusable = true}}, SHIFT(57),
+  [171] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_backspace, 2),
+  [173] = {.entry = {.count = 1, .reusable = true}}, SHIFT(58),
+  [175] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_setting, 2),
+  [177] = {.entry = {.count = 1, .reusable = true}}, SHIFT(34),
+  [179] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_pagedown, 2),
+  [181] = {.entry = {.count = 1, .reusable = true}}, SHIFT(35),
+  [183] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_pageup, 2),
+  [185] = {.entry = {.count = 1, .reusable = true}}, SHIFT(39),
+  [187] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_up, 2),
+  [189] = {.entry = {.count = 1, .reusable = true}}, SHIFT(41),
+  [191] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tab, 2),
+  [193] = {.entry = {.count = 1, .reusable = true}}, SHIFT(45),
+  [195] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_space, 2),
+  [197] = {.entry = {.count = 1, .reusable = true}}, SHIFT(47),
+  [199] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_right, 2),
+  [201] = {.entry = {.count = 1, .reusable = true}}, SHIFT(49),
+  [203] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_left, 2),
+  [205] = {.entry = {.count = 1, .reusable = true}}, SHIFT(51),
+  [207] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_escape, 2),
+  [209] = {.entry = {.count = 1, .reusable = true}}, SHIFT(53),
+  [211] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_enter, 2),
+  [213] = {.entry = {.count = 1, .reusable = true}}, SHIFT(55),
+  [215] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_hide, 1),
+  [217] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_setting, 3),
+  [219] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_pagedown, 3),
+  [221] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_command, 1),
+  [223] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_pageup, 3),
+  [225] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_up, 3),
+  [227] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_set, 2),
   [229] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tab, 3),
   [231] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_space, 3),
   [233] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_right, 3),
-  [235] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_output, 2),
-  [237] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_left, 3),
-  [239] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_escape, 3),
-  [241] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_enter, 3),
-  [243] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_down, 3),
-  [245] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_backspace, 3),
-  [247] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_hide, 1),
+  [235] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_left, 3),
+  [237] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_escape, 3),
+  [239] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_enter, 3),
+  [241] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_down, 3),
+  [243] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_backspace, 3),
+  [245] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_sleep, 2),
+  [247] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_output, 2),
   [249] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_show, 1),
   [251] = {.entry = {.count = 1, .reusable = true}}, SHIFT(66),
-  [253] = {.entry = {.count = 1, .reusable = true}}, SHIFT(70),
-  [255] = {.entry = {.count = 1, .reusable = true}}, SHIFT(71),
-  [257] = {.entry = {.count = 1, .reusable = true}}, SHIFT(72),
-  [259] = {.entry = {.count = 1, .reusable = true}}, SHIFT(65),
-  [261] = {.entry = {.count = 1, .reusable = true}}, SHIFT(73),
-  [263] = {.entry = {.count = 1, .reusable = false}}, SHIFT(71),
+  [253] = {.entry = {.count = 1, .reusable = true}}, SHIFT(68),
+  [255] = {.entry = {.count = 1, .reusable = true}}, SHIFT(69),
+  [257] = {.entry = {.count = 1, .reusable = true}}, SHIFT(70),
+  [259] = {.entry = {.count = 1, .reusable = true}}, SHIFT(64),
+  [261] = {.entry = {.count = 1, .reusable = true}}, SHIFT(71),
+  [263] = {.entry = {.count = 1, .reusable = false}}, SHIFT(69),
   [265] = {.entry = {.count = 1, .reusable = false}}, SHIFT(66),
-  [267] = {.entry = {.count = 1, .reusable = true}}, SHIFT(58),
-  [269] = {.entry = {.count = 1, .reusable = true}}, SHIFT(52),
-  [271] = {.entry = {.count = 1, .reusable = true}}, SHIFT(36),
-  [273] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
-  [275] = {.entry = {.count = 1, .reusable = true}}, SHIFT(30),
-  [277] = {.entry = {.count = 1, .reusable = true}}, SHIFT(7),
+  [267] = {.entry = {.count = 1, .reusable = true}}, SHIFT(72),
+  [269] = {.entry = {.count = 1, .reusable = true}}, SHIFT(32),
+  [271] = {.entry = {.count = 1, .reusable = true}}, SHIFT(60),
+  [273] = {.entry = {.count = 1, .reusable = true}}, SHIFT(22),
+  [275] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
+  [277] = {.entry = {.count = 1, .reusable = true}}, SHIFT(59),
+  [279] = {.entry = {.count = 1, .reusable = true}}, SHIFT(7),
 };
 
 #ifdef __cplusplus

--- a/test.tape
+++ b/test.tape
@@ -11,6 +11,7 @@ Set MarginFill "#FFFFFF"
 Set BorderRadius 10
 Set WindowBar "Colorful"
 Set WindowBarSize 40
+Set CursorBlink false
 
 Sleep 1s
 

--- a/test/corpus/all.txt
+++ b/test/corpus/all.txt
@@ -40,6 +40,7 @@ Set MarginFill "#FFFFFF"
 Set BorderRadius 10
 Set WindowBar "Colorful"
 Set WindowBarSize 40
+Set CursorBlink false
 
 ---
 
@@ -64,7 +65,8 @@ Set WindowBarSize 40
   (command (set (setting (string))))
   (command (set (setting (integer))))
   (command (set (setting (string))))
-  (command (set (setting (integer)))))
+  (command (set (setting (integer))))
+  (command (set (setting (boolean)))))
 
 
 ========


### PR DESCRIPTION
Adds the `CursorBlink` setting (https://github.com/charmbracelet/vhs/commit/46cf42f4fd867ceb7d47fdf5f76df7f2336c4f1f). Updated the tests (first time with that style of tests, lmk if it looks wrong), ran them and it worked fine. ~~I wasn't able to run the `highlight` script because of some difficulties with tree-sitter though.~~ I ran the `highlight` script but noticed that it wasn't highlighting some parts:

<img src="https://github.com/charmbracelet/tree-sitter-vhs/assets/47499684/cda5eb7e-c7cc-43c4-8479-5ed63395632e" width="200">

I re-cloned, re-installed, etc and tested it on the latest commit to `main` and the issue is still present- I assume it's working in neovim and other places that use the grammar so is tree-sitter-cli just not working here? Is it just me? 